### PR TITLE
Fixes group create file permissions

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -167,7 +167,7 @@ commodore () {
     --interactive=true \
     --tty \
     --rm \
-    --user="$(id -u)" \
+    --user="$(id -u):$(id -u)" \
     --volume "$HOME"/.ssh:/app/.ssh:ro \
     --volume "$PWD"/compiled/:/app/compiled/ \
     --volume "$PWD"/catalog/:/app/catalog \


### PR DESCRIPTION
Without this, all files will be created with group = root
And then commands to prepare Terraform cluster config fail