### PR TITLE
Add generate a self signed ingress certificate

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
+++ b/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
@@ -1,0 +1,99 @@
+= Self-signed default ingress certificate
+
+[NOTE]
+--
+Steps to implement a self-signed default ingress certificate for the OpenShift Router. This isn't meant to be used in production!
+
+These steps follow the https://docs.openshift.com/container-platform/4.6/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress[Replacing the default ingress certificate] docs to set up a regular commercial certificate.
+--
+
+== Generate a self-signed ingress certificate
+
+A private key and certificate is generated using the https://www.openssl.org[openssl] command line tool. OpenShift requires the configuration of the Subject Alternative Name (SAN). The distinguished name (DN) Common Name (CN) must be equal to the SAN wildcard domain, in example `*.apps.<cluster>.<domain>.<tld>`.
+
+. Create the private key `ingress.key` and the certificate `ingress.crt` in a single step:
++
+[source,console]
+----
+openssl req -x509 -out ingress.crt -keyout ingress.key -config <(
+cat <<-EOF
+[ req ]
+prompt = no
+encrypt_key = no
+default_bits = 4096
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_req
+
+[ dn ]
+C = AU
+ST = Some-State
+O = Internet Widgits Pty Ltd
+CN = *.apps.<cluster>.<domain>.<tld>
+
+[ v3_req ]
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+basicConstraints = critical,CA:false
+subjectKeyIdentifier = hash
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = *.apps.<cluster>.<domain>.<tld>
+EOF
+)
+----
+
+. Verify the wildcard certificate has been created in a valid form with a SAN:
++
+[source,console]
+----
+openssl x509 -noout -text -in ingress.crt | grep -A1 'X509v3 Subject Alternative Name'
+----
+
+== Configure the generated self signed ingress certificate in OpenShift
+
+[NOTE]
+--
+Because the self-signed certificate has been created without a CA, the certificate itself is stored in the custom-ca configmap. This ensures the created certificate is accepted as valid.
+--
+
+. Create a custom-ca configmap with the ingress certificate:
++
+[source,console]
+----
+oc create configmap custom-ca \
+   --from-file=ca-bundle.crt=ingress.crt \
+   -n openshift-config
+----
+
+. Update the cluster-wide proxy configuration with the newly created config map:
++
+[source,console]
+----
+oc patch proxy/cluster \
+   --type=merge \
+   --patch='{"spec":{"trustedCA":{"name":"custom-ca"}}}'
+----
+
+. Create the secret with the key and the self-signed certificate:
++
+[source,console]
+----
+oc create secret tls self-signed-wildcard \
+   --cert=ingress.crt \
+   --key=ingress.key \
+   -n openshift-ingress
+----
+
+. Configure the `self-signed-wildcard` secret via the Syn https://github.com/appuio/component-openshift4-ingress[openshift4-ingress component]:
++
+[source,yaml]
+----
+parameters:
+  openshift4_ingress:
+    ingressControllers:
+      default:
+        defaultCertificate:
+          name: self-signed-wildcard
+----

--- a/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
+++ b/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
@@ -18,8 +18,7 @@ The distinguished name (DN) Common Name (CN) must be equal to the SAN wildcard d
 +
 [source,console]
 ----
-openssl req -x509 -out ingress.crt -keyout ingress.key -config <(
-cat <<-EOF | openssl req -x509 -out ingress.crt -keyout ingress.key -config
+cat <<-EOF | openssl req -x509 -out ingress.crt -keyout ingress.key -config -
 [ req ]
 prompt = no
 encrypt_key = no
@@ -44,7 +43,6 @@ subjectAltName = @alt_names
 [ alt_names ]
 DNS.1 = *.apps.<cluster>.<domain>.<tld>
 EOF
-)
 ----
 
 . Verify the wildcard certificate has been created in a valid form with a SAN:

--- a/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
+++ b/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
@@ -1,8 +1,8 @@
-= Self-signed default ingress certificate
+= Self-signed default Ingress certificate
 
 [NOTE]
 --
-Steps to implement a self-signed default ingress certificate for the OpenShift Router. This isn't meant to be used in production!
+Steps to implement a self-signed default Ingress certificate for the OpenShift Router. This isn't meant to be used in production!
 
 These steps follow the https://docs.openshift.com/container-platform/4.6/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress[Replacing the default ingress certificate] docs to set up a regular commercial certificate.
 --
@@ -51,14 +51,14 @@ EOF
 openssl x509 -noout -text -in ingress.crt | grep -A1 'X509v3 Subject Alternative Name'
 ----
 
-== Configure the generated self signed ingress certificate in OpenShift
+== Configure the generated self signed Ingress certificate in OpenShift
 
 [NOTE]
 --
 Because the self-signed certificate has been created without a CA, the certificate itself is stored in the custom-ca configmap. This ensures the created certificate is accepted as valid.
 --
 
-. Create a custom-ca configmap with the ingress certificate:
+. Create a custom-ca ConfigMap with the Ingress certificate:
 +
 [source,console]
 ----
@@ -67,7 +67,7 @@ oc create configmap custom-ca \
    -n openshift-config
 ----
 
-. Update the cluster-wide proxy configuration with the newly created config map:
+. Update the cluster-wide proxy configuration with the newly created ConfigMap:
 +
 [source,console]
 ----
@@ -86,7 +86,7 @@ oc create secret tls self-signed-wildcard \
    -n openshift-ingress
 ----
 
-. Configure the `self-signed-wildcard` secret via the Syn https://github.com/appuio/component-openshift4-ingress[openshift4-ingress component]:
+. Configure the `self-signed-wildcard` secret via the Project Syn https://github.com/appuio/component-openshift4-ingress[openshift4-ingress component]:
 +
 [source,yaml]
 ----

--- a/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
+++ b/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
@@ -55,10 +55,10 @@ openssl x509 -noout -text -in ingress.crt | grep -A1 'X509v3 Subject Alternative
 
 [NOTE]
 --
-Because the self-signed certificate has been created without a CA, the certificate itself is stored in the custom-ca configmap. This ensures the created certificate is accepted as valid.
+Because the self-signed certificate has been created without a CA, the certificate itself is stored in the `custom-ca` ConfigMap. This ensures the created certificate is accepted as valid.
 --
 
-. Create a custom-ca ConfigMap with the Ingress certificate:
+. Create a ConfigMap `custom-ca` with the Ingress certificate:
 +
 [source,console]
 ----

--- a/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
+++ b/docs/modules/ROOT/pages/how-tos/ingress/self-signed-ingress-cert.adoc
@@ -1,22 +1,25 @@
 = Self-signed default Ingress certificate
 
 [NOTE]
---
-Steps to implement a self-signed default Ingress certificate for the OpenShift Router. This isn't meant to be used in production!
+====
+Steps to implement a self-signed default Ingress certificate for the OpenShift Router.
+This isn't meant to be used in production!
 
 These steps follow the https://docs.openshift.com/container-platform/4.6/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress[Replacing the default ingress certificate] docs to set up a regular commercial certificate.
---
+====
 
 == Generate a self-signed ingress certificate
 
-A private key and certificate is generated using the https://www.openssl.org[openssl] command line tool. OpenShift requires the configuration of the Subject Alternative Name (SAN). The distinguished name (DN) Common Name (CN) must be equal to the SAN wildcard domain, in example `*.apps.<cluster>.<domain>.<tld>`.
+A private key and certificate is generated using the https://www.openssl.org[openssl] command line tool.
+OpenShift requires the configuration of the Subject Alternative Name (SAN).
+The distinguished name (DN) Common Name (CN) must be equal to the SAN wildcard domain, in example `*.apps.<cluster>.<domain>.<tld>`.
 
 . Create the private key `ingress.key` and the certificate `ingress.crt` in a single step:
 +
 [source,console]
 ----
 openssl req -x509 -out ingress.crt -keyout ingress.key -config <(
-cat <<-EOF
+cat <<-EOF | openssl req -x509 -out ingress.crt -keyout ingress.key -config
 [ req ]
 prompt = no
 encrypt_key = no
@@ -55,7 +58,8 @@ openssl x509 -noout -text -in ingress.crt | grep -A1 'X509v3 Subject Alternative
 
 [NOTE]
 --
-Because the self-signed certificate has been created without a CA, the certificate itself is stored in the `custom-ca` ConfigMap. This ensures the created certificate is accepted as valid.
+Because the self-signed certificate has been created without a CA, the certificate itself is stored in the `custom-ca` ConfigMap.
+This ensures the created certificate is accepted as valid.
 --
 
 . Create a ConfigMap `custom-ca` with the Ingress certificate:

--- a/docs/modules/ROOT/partials/nav-howtos.adoc
+++ b/docs/modules/ROOT/partials/nav-howtos.adoc
@@ -5,6 +5,9 @@
 * Authentication
 ** xref:oc4:ROOT:how-tos/authentication/sudo.adoc[Sudo]
 
+* Ingress
+** xref:oc4:ROOT:how-tos/ingress/self-signed-ingress-cert.adoc[Self-signed default ingress certificate]
+
 * cloudscale.ch
 ** xref:oc4:ROOT:how-tos/cloudscale/install.adoc[Cluster Setup]
 ** xref:oc4:ROOT:how-tos/cloudscale/decommission.adoc[Cluster Decommission]


### PR DESCRIPTION
For test clusters it might be valid to use a self-signed
OpenShift 4 default ingress certificate. Because there is
no documentation available in the internet as of today,
this should be added to your knowledge base.