### PR TITLE
Add `global-backup/password` to list of secrets to generate for Cloudscale installation

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -149,7 +149,11 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/registry \
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/vshn-ldap \
   bindPassword=${LDAP_PASSWORD}
 
-# Generate a master password for backups
+# Generate a master password for K8up backups
+vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/global-backup \
+  password=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
+
+# Generate a password for the cluster object backups
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
   password=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
 ----


### PR DESCRIPTION
Currently the Commodore component backup-k8up requires the secret `global-backup/password` to be present for the cluster in Vault, if the setting `global_backup_config.enabled` is `true`.

Since we use other parts of `global_backup_config` to provide sensible defaults for VSHN-managed OpenShift4 on Cloudscale we have to set the global-backup/password secret.