### PR TITLE
Lookup Gitlab project ID

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
@@ -30,7 +30,6 @@ export CLUSTER_ID=<lieutenant-cluster-id>
 export TENANT_ID=<lieutenant-tenant-id>
 export REGION=<region> # rma or lpg (without the zone number)
 export GITLAB_TOKEN=<gitlab-api-token> # From https://git.vshn.net/profile/personal_access_tokens
-export GITLAB_CATALOG_PROJECT_ID=<project-id> # GitLab numerical project ID of the catalog repo
 ----
 
 include::partial$setup_terraform.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -74,7 +74,6 @@ export LDAP_PASSWORD="Your_LDAP_pw_here"
 ----
 export CLOUDSCALE_TOKEN=<cloudscale-api-token> # From https://control.cloudscale.ch/user/api-tokens
 export GITLAB_TOKEN=<gitlab-api-token> # From https://git.vshn.net/profile/personal_access_tokens
-export GITLAB_CATALOG_PROJECT_ID=<project-id> # GitLab numerical project ID of the catalog repo
 export REGION=rma # rma or lpg (without the zone number)
 export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-<verb>-<noun>-<number>
 export TENANT_ID=<lieutenant-tenant-id> # Looks like: t-<verb>-<noun>-<number>

--- a/docs/modules/ROOT/partials/setup_terraform.adoc
+++ b/docs/modules/ROOT/partials/setup_terraform.adoc
@@ -22,6 +22,8 @@ alias terraform='docker run -it --rm \
   --ulimit memlock=-1 \
   ${tf_image}:${tf_tag} terraform'
 
+export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||' | sed 's|/|:|')
+export GITLAB_CATALOG_PROJECT_ID=$(curl -sH "Authorization: Bearer ${GITLAB_TOKEN}" "https://git.vshn.net/api/v4/projects?simple=true&search=${CLUSTER_ID}" | jq -r ".[] | select(.ssh_url_to_repo == \"${GITLAB_REPOSITORY_URL}\") | .id")
 export GITLAB_STATE_URL="https://git.vshn.net/api/v4/projects/${GITLAB_CATALOG_PROJECT_ID}/terraform/state/cluster"
 
 pushd catalog/manifests/openshift4-cloudscale/

--- a/docs/modules/ROOT/partials/setup_terraform.adoc
+++ b/docs/modules/ROOT/partials/setup_terraform.adoc
@@ -22,8 +22,9 @@ alias terraform='docker run -it --rm \
   --ulimit memlock=-1 \
   ${tf_image}:${tf_tag} terraform'
 
-export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||' | sed 's|/|:|')
-export GITLAB_CATALOG_PROJECT_ID=$(curl -sH "Authorization: Bearer ${GITLAB_TOKEN}" "https://git.vshn.net/api/v4/projects?simple=true&search=${CLUSTER_ID}" | jq -r ".[] | select(.ssh_url_to_repo == \"${GITLAB_REPOSITORY_URL}\") | .id")
+export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||; s|/|:|')
+export GITLAB_REPOSITORY_NAME=${GITLAB_REPOSITORY_URL##*/}
+export GITLAB_CATALOG_PROJECT_ID=$(curl -sH "Authorization: Bearer ${GITLAB_TOKEN}" "https://git.vshn.net/api/v4/projects?simple=true&search=${GITLAB_REPOSITORY_NAME/.git}" | jq -r ".[] | select(.ssh_url_to_repo == \"${GITLAB_REPOSITORY_URL}\") | .id")
 export GITLAB_STATE_URL="https://git.vshn.net/api/v4/projects/${GITLAB_CATALOG_PROJECT_ID}/terraform/state/cluster"
 
 pushd catalog/manifests/openshift4-cloudscale/


### PR DESCRIPTION
Remove the need to search for `GITLAB_CATALOG_PROJECT_ID` in the Gitlab
UI.