### PR TITLE
Fix Terraform command alias to allow copy-pasting using new style

### DIFF
--- a/docs/modules/ROOT/partials/setup_terraform.adoc
+++ b/docs/modules/ROOT/partials/setup_terraform.adoc
@@ -19,7 +19,7 @@ alias terraform='docker run -it --rm \
   -w /tf \
   -v $(pwd):/tf \
   --ulimit memlock=-1 \
-  ${tf_image}:${tf_tag} terraform'
+  "${tf_image}:${tf_tag}" terraform'
 
 export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||; s|/|:|')
 export GITLAB_REPOSITORY_NAME=${GITLAB_REPOSITORY_URL##*/}

--- a/docs/modules/ROOT/partials/setup_terraform_exoscale.adoc
+++ b/docs/modules/ROOT/partials/setup_terraform_exoscale.adoc
@@ -19,7 +19,7 @@ alias terraform='docker run -it --rm \
   -w /tf \
   -v $(pwd):/tf \
   --ulimit memlock=-1 \
-  ${tf_image}:${tf_tag} terraform'
+  "${tf_image}:${tf_tag}" terraform'
 
 export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||; s|/|:|')
 export GITLAB_REPOSITORY_NAME=${GITLAB_REPOSITORY_URL##*/}


### PR DESCRIPTION
With the new style for kb.vshn.ch, the Terraform alias didn't get copy-pasted correctly anymore. This commit fixes the alias to ensure it gets copied correctly.