### PR TITLE
Fix Exoscale storage node management how-tos

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/exoscale/change_storage_node_size.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/change_storage_node_size.adoc
@@ -14,7 +14,7 @@
 :delete-nodes-manually: yes
 :node-delete-list: $NODES_TO_REPLACE
 
-:delete-pvs: $old_pv_names
+:delete-pvs: old_pv_names
 
 [abstract]
 --

--- a/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
@@ -7,6 +7,7 @@
 :osd-replace-list: $NODE_TO_REMOVE
 
 :mon-operation: remove
+:mon-argocd-autosync-already-disabled: yes
 :mon-replace-list: $NODE_TO_REMOVE
 
 :node-delete-list: ${NODE_TO_REMOVE}

--- a/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
@@ -11,7 +11,7 @@
 
 :node-delete-list: ${NODE_TO_REMOVE}
 :delete-nodes-manually: no
-:delete-pvs: $old_pv_names
+:delete-pvs: old_pv_names
 
 [abstract]
 --

--- a/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
@@ -136,6 +136,14 @@ include::partial$storage-ceph-remove-osd.adoc[]
 
 include::partial$storage-ceph-cleanup-osd.adoc[]
 
+. Scale up the Rook-Ceph operator
++
+[source,bash]
+----
+kubectl --as=cluster-admin -n syn-rook-ceph-operator scale --replicas=1 \
+  deploy/rook-ceph-operator
+----
+
 === Remove the old MON
 
 include::partial$storage-ceph-remove-mon.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
@@ -4,10 +4,10 @@
 :delabel_app_nodes: yes
 :argo_app: rook-ceph
 
-:osd-replace-list: $NODE_TO_REPLACE
+:osd-replace-list: $NODE_TO_REMOVE
 
 :mon-operation: remove
-:mon-replace-list: $NODE_TO_REPLACE
+:mon-replace-list: $NODE_TO_REMOVE
 
 :node-delete-list: ${NODE_TO_REMOVE}
 :delete-nodes-manually: no

--- a/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/remove_storage_node.adoc
@@ -119,6 +119,18 @@ kubectl --as=cluster-admin -n syn-rook-ceph-cluster \
   get cephcluster cluster -o jsonpath='{.spec.storage.storageClassDeviceSets[0].count}'
 ----
 
+. Disable ArgoCD auto sync for component `rook-ceph`
++
+include::partial$disable-argocd-autosync.adoc[]
+
+. Scale down the Rook-Ceph operator
++
+[source,bash]
+----
+kubectl --as=cluster-admin -n syn-rook-ceph-operator scale --replicas=0 \
+  deploy/rook-ceph-operator
+----
+
 include::partial$storage-ceph-remove-osd.adoc[]
 
 include::partial$storage-ceph-cleanup-osd.adoc[]
@@ -134,6 +146,8 @@ include::partial$exoscale/delete-node.adoc[]
 == Finish up
 
 include::partial$remove-alertmanager-silence.adoc[]
+
+include::partial$enable-argocd-autosync.adoc[]
 
 == Upstream documentation
 

--- a/docs/modules/ROOT/pages/how-tos/exoscale/replace_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/replace_storage_node.adoc
@@ -12,7 +12,7 @@
 
 :node-delete-list: ${NODE_TO_REPLACE}
 :delete-nodes-manually: yes
-:delete-pvs: $old_pv_names
+:delete-pvs: old_pv_names
 
 [abstract]
 --

--- a/docs/modules/ROOT/partials/exoscale/delete-node.adoc
+++ b/docs/modules/ROOT/partials/exoscale/delete-node.adoc
@@ -43,6 +43,8 @@ ifeval::["{delete-nodes-manually}" != "yes"]
 Verify that the hostname of the to be deleted node(s) matches `{node-delete-list}`
 ====
 +
+NOTE: Ensure that you're still in directory `${WORK_DIR}/catalog/manifests/openshift4-terraform` before executing this command.
++
 [source,bash]
 ----
 terraform apply

--- a/docs/modules/ROOT/partials/exoscale/delete-node.adoc
+++ b/docs/modules/ROOT/partials/exoscale/delete-node.adoc
@@ -54,7 +54,7 @@ endif::[]
 +
 [source,bash,subs="attributes+"]
 ----
-for pv_name in $(echo -n {delete-pvs}); do
+for pv_name in $(echo -n ${delete-pvs}); do
   kubectl --as=cluster-admin delete pv "${pv_name}"
 done
 ----

--- a/docs/modules/ROOT/partials/storage-ceph-remove-osd.adoc
+++ b/docs/modules/ROOT/partials/storage-ceph-remove-osd.adoc
@@ -33,7 +33,7 @@ for node in $(echo -n {osd-replace-list}); do
   kubectl --as=cluster-admin -n syn-rook-ceph-cluster exec -it deploy/rook-ceph-tools -- \
     ceph osd purge "${osd_id}"
   kubectl --as=cluster-admin -n syn-rook-ceph-cluster exec -it deploy/rook-ceph-tools -- \
-    ceph osd crush remove "${osd_id}"
+    ceph osd crush remove "${node}"
 done
 ----
 


### PR DESCRIPTION
* Remove node from crushmap instead of OSD id
* Fix how we use the `delete-pvs` page attribute
* Fix copy-paste errors in "Remove storage node" how-to
* Scale down the rook-ceph operator in "Remove storage node" how-to