### PR TITLE
Add a warning about restoring all objects at once from backup

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
@@ -142,5 +142,8 @@ kubectl --as cluster-admin apply -Rf <path/to/dir>
 
 [WARNING]
 ====
-While it's technically possible to extract all files in the backup and apply them all, it's not advisable to do so. Restoring objects that are managed by ArgoCD, will prevent most ArgoCD-managed apps from successfully syncing. These objects would then need to be replaced manually. Try to limit the objects being restored to the necessary minimum.
+While it's technically possible to restore all objects from a backup it's not advisable to do so.
+Restoring objects that are managed by ArgoCD will prevent most ArgoCD-managed apps from successfully syncing.
+These objects would then need to be replaced manually.
+Try to limit the objects being restored to the necessary minimum.
 ====

--- a/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
@@ -97,7 +97,7 @@ restic snapshots
 +
 [source,console]
 ----
-restic restore <ID> --target . 
+restic restore <ID> --target .
 ----
 
 == Extract and prepare files
@@ -139,3 +139,8 @@ kubectl --as cluster-admin apply -f <path/to/file>
 ----
 kubectl --as cluster-admin apply -Rf <path/to/dir>
 ----
+
+[WARNING]
+====
+While it's technically possible to extract all files in the backup and apply them all, it's not advisable to do so. Restoring objects that are managed by ArgoCD, will prevent most ArgoCD-managed apps from successfully syncing. These objects would then need to be replaced manually. Try to limit the objects being restored to the necessary minimum.
+====


### PR DESCRIPTION
When trying to test the object backup for a new cluster, I naively tried to restore all objects in the backup in the spirit of "a backup is only useful if you've successfully restored from it". This majorly tripped ArgoCD and led to a lot of manual fixing.

This PR adds a warning to not "blindly" restore all objects. Open to suggestions about the wording, might be a bit long-winded still.