### PR TITLE
Document fix for S3 public access block config

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -326,4 +326,12 @@ oc create secret generic image-registry-private-configuration-user \
 --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=$(mc config host ls ${CLUSTER_ID} -json | jq -r .secretKey)
 ----
 
+. Once the bucket has been created by openshift you need to adjust the public-access-block settings of the bucket due to a bug in the https://tracker.ceph.com/issues/49135[Ceph S3 implementation]
++
+[source,bash]
+----
+export REGION=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .facts.region)
+aws --endpoint-url https://objects.${REGION}.cloudscale.ch s3api put-public-access-block --bucket ${CLUSTER_ID}-image-registry --public-access-block-configuration BlockPublicAcls=false
+----
+
 include::partial$install/finalize.adoc[]


### PR DESCRIPTION
Due to a bug in the Ceph S3 implementation (https://tracker.ceph.com/issues/49135) the registry bucket created by openshift contains a "faulty" public-access-block configuration and needs to be adjusted.