### PR TITLE
Add steps to configure acme-dns challenges during cluster setup

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -207,6 +207,10 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
 # Copy the Dagobert OpenShift Node Collector Credentials
 vault kv get -format=json "clusters/kv/template/dagobert" | jq '.data.data' \
   | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/dagobert" -
+
+# Copy the VSHN acme-dns registration password
+vault kv get -format=json "clusters/kv/template/cert-manager" | jq '.data.data' \
+  | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cert-manager" -
 ----
 
 include::partial$get-hieradata-token-from-vault.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -158,6 +158,10 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
 # Copy the Dagobert OpenShift Node Collector Credentials
 vault kv get -format=json "clusters/kv/template/dagobert" | jq '.data.data' \
   | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/dagobert" -
+
+# Copy the VSHN acme-dns registration password
+vault kv get -format=json "clusters/kv/template/cert-manager" | jq '.data.data' \
+  | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cert-manager" -
 ----
 
 include::partial$get-hieradata-token-from-vault.adoc[]

--- a/docs/modules/ROOT/partials/install/finalize.adoc
+++ b/docs/modules/ROOT/partials/install/finalize.adoc
@@ -22,6 +22,41 @@ ls -l ${INSTALLER_DIR}/auth/
 
 . https://kb.vshn.ch/vshnsyn/how-tos/synthesize.html[Make the cluster Project Syn enabled]
 
+=== Setup acme-dns CNAME records for the cluster
+
+. Extract the acme-dns subdomain for the cluster after `cert-manager` has been deployed via Project Syn.
++
+[source,bash]
+----
+fulldomain=$(kubectl -n syn-cert-manager \
+  get secret acme-dns-client \
+  -o jsonpath='{.data.acmedns\.json}' | \
+  base64 -d  | \
+  jq -r '[.[]][0].fulldomain')
+echo "$fulldomain"
+----
+
+ifeval::["{provider}" == "cloudscale"]
+. Add the following CNAME records to the cluster's DNS zone
++
+[source,dns]
+----
+_acme-challenge.api  IN CNAME <fulldomain>. <1>
+_acme-challenge.apps IN CNAME <fulldomain>. <1>
+----
+<1> Replace `<fulldomain>` with the output of the previous step.
+endif::[]
+ifeval::["{provider}" == "exoscale"]
+. Setup the `_acme-challenge` CNAME records in the cluster's DNS zone
++
+[source,bash]
+----
+for cname in "api" "apps"; do
+  exo dns add CNAME "${CLUSTER_ID}.${BASE_DOMAIN}" -n "_acme-challenge.${cname}" -a "${fulldomain}." -t 600
+done
+----
+endif::[]
+
 === Finalize installation
 
 . Configure the apt-dater groups for the LBs.

--- a/docs/modules/ROOT/partials/install/finalize.adoc
+++ b/docs/modules/ROOT/partials/install/finalize.adoc
@@ -1,14 +1,3 @@
-. Create wildcard cert for router
-+
-[source,bash]
-----
-kubectl get secret router-certs-default \
-  -n openshift-ingress \
-  -o json | \
-    jq 'del(.metadata.ownerReferences) | .metadata.name = "router-certs-snakeoil"' | \
-  kubectl -n openshift-ingress apply -f -
-----
-
 . Save the admin credentials in the https://password.vshn.net[password manager].
 You can find the password in the file `target/auth/kubeadmin-password` and the kubeconfig in `target/auth/kubeconfig`
 +

--- a/docs/modules/ROOT/partials/install/prepare-terraform.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-terraform.adoc
@@ -31,7 +31,10 @@ yq eval -i ".parameters.openshift.infraID = \"$(jq -r .infraID "${INSTALLER_DIR}
 yq eval -i ".parameters.openshift.clusterID = \"$(jq -r .clusterID "${INSTALLER_DIR}/metadata.json")\"" \
   ${CLUSTER_ID}.yml
 
-yq eval -i ".parameters.openshift.appsDomain = \"apps.${CLUSTER_ID}.${BASE_DOMAIN}\"" \
+yq eval -i ".parameters.openshift.baseDomain = \"${CLUSTER_ID}.${BASE_DOMAIN}\"" \
+  ${CLUSTER_ID}.yml
+
+yq eval -i '.parameters.openshift.appsDomain = "apps.${openshift:baseDomain}"' \
   ${CLUSTER_ID}.yml
 
 yq eval -i ".parameters.openshift4_terraform.terraform_variables.base_domain = \"${BASE_DOMAIN}\"" \


### PR DESCRIPTION
* Copy Vault secret for acme-dns registration on acme-dns-api.vshn.net
* Ensure parameters `openshift.baseDomain` and `openshift.appsDomain` are both set in the cluster's Project Syn parameters.
* Extract acme-dns domain and setup CNAME records for cluster zone.
* Remove step to deploy a snakeoil certificate for the default ingress