### PR TITLE
syn-cluster-backup secret renamed to objects-backup-s3-credentials

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
@@ -28,8 +28,8 @@ They can also be obtained from the cluster catalog and Vault.
 ----
 export RESTIC_REPOSITORY=$(kubectl -n syn-cluster-backup get schedule objects -o jsonpath='s3:{.spec.backend.s3.endpoint}/{.spec.backend.s3.bucket}')
 export RESTIC_PASSWORD=$(kubectl --as cluster-admin -n syn-cluster-backup get secret objects-backup-password -o jsonpath='{.data.password}' | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(kubectl --as cluster-admin -n syn-cluster-backup get secret object-backup-s3-credentials -o jsonpath='{.data.username}' | base64 --decode)
-export AWS_SECRET_ACCESS_KEY=$(kubectl --as cluster-admin -n syn-cluster-backup get secret object-backup-s3-credentials -o jsonpath='{.data.password}' | base64 --decode)
+export AWS_ACCESS_KEY_ID=$(kubectl --as cluster-admin -n syn-cluster-backup get secret objects-backup-s3-credentials -o jsonpath='{.data.username}' | base64 --decode)
+export AWS_SECRET_ACCESS_KEY=$(kubectl --as cluster-admin -n syn-cluster-backup get secret objects-backup-s3-credentials -o jsonpath='{.data.password}' | base64 --decode)
 ----
 
 === Obtaining restic configuration from catalog and vault


### PR DESCRIPTION
The secret has been renamed from object-backup-s3-credentials to
objects-backup-s3-credentials.