### PR TITLE
Set team responsible for LBaaS Icinga alerts at install time

### DIFF
--- a/docs/modules/ROOT/partials/install/prepare-terraform.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-terraform.adoc
@@ -12,6 +12,15 @@ mkdir -p inventory/classes/
 git clone $(curl -sH"Authorization: Bearer ${COMMODORE_API_TOKEN}" "${COMMODORE_API_URL}/tenants/${TENANT_ID}" | jq -r '.gitRepo.url') inventory/classes/${TENANT_ID}
 ----
 
+. Set team responsible for handling Icinga alerts
++
+[source,bash]
+----
+# use lower case for team name.
+# e.g. TEAM=tarazed
+TEAM=<team-name>
+----
+
 . Prepare Terraform cluster config
 +
 [source,bash,subs="attributes+"]
@@ -53,6 +62,9 @@ yq eval -i ".parameters.openshift4_terraform.terraform_variables.ssh_keys = [\"$
 endif::[]
 
 yq eval -i ".parameters.openshift4_terraform.terraform_variables.hieradata_repo_user = \"${HIERADATA_REPO_USER}\"" \
+  ${CLUSTER_ID}.yml
+
+yq eval -i ".parameters.openshift4_terraform.terraform_variables.team = \"${TEAM}\"" \
   ${CLUSTER_ID}.yml
 
 # Configure the OpenShift update channel


### PR DESCRIPTION
This PR adds documentation on how to set the team responsible for LBaaS Icinga alerts at install time.