### PR TITLE
Respect exoscale zones in cluster setup instructions

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -89,7 +89,7 @@ export TF_VAR_lb_exoscale_api_key=$(exo iam apikey show "${CLUSTER_ID}_floaty" \
 +
 [source,bash]
 ----
-exo storage create "sos://${CLUSTER_ID}-bootstrap"
+exo storage create "sos://${CLUSTER_ID}-bootstrap" --zone "${EXOSCALE_ZONE}"
 ----
 
 === Upload Red Hat CoreOS image
@@ -109,6 +109,7 @@ virt-edit -a rhcos-${RHCOS_VERSION}.qcow2 \
 exo storage upload rhcos-${RHCOS_VERSION}.qcow2 "sos://${CLUSTER_ID}-bootstrap" --acl public-read
 
 exo vm template register "rhcos-${RHCOS_VERSION}" \
+  --zone "${EXOSCALE_ZONE}" \
   --checksum $(md5sum rhcos-${RHCOS_VERSION}.qcow2 | awk '{ print $1 }') \
   --boot-mode uefi \
   --disable-password \

--- a/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
+++ b/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
@@ -6,7 +6,7 @@ export EXOSCALE_API_KEY=<exoscale-key>
 export EXOSCALE_API_SECRET=<exoscale-secret>
 export EXOSCALE_REGION=<exoscale-zone> <1>
 
-export EXOSCALE_CONFIG=`pwd`/exoscale.toml
+export EXOSCALE_CONFIG=$(pwd)/exoscale.toml
 export EXOSCALE_S3_ENDPOINT="sos-${EXOSCALE_REGION}.exo.io"
 
 cat <<EOF > "$EXOSCALE_CONFIG"

--- a/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
+++ b/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
@@ -1,9 +1,26 @@
 .Access to cloud API
 [source,bash]
 ----
-export EXOSCALE_ACCOUNT=<exoscale-account>
+
 export EXOSCALE_API_KEY=<exoscale-key>
 export EXOSCALE_API_SECRET=<exoscale-secret>
-export EXOSCALE_REGION=<exoscale-zone>
+export EXOSCALE_REGION=<exoscale-zone> <1>
+
+export EXOSCALE_CONFIG=`pwd`/exoscale.toml
 export EXOSCALE_S3_ENDPOINT="sos-${EXOSCALE_REGION}.exo.io"
+
+cat <<EOF > "$EXOSCALE_CONFIG"
+defaultaccount = "cluster-setup"
+
+[[accounts]]
+  name = "cluster-setup"
+
+  defaultZone = "${EXOSCALE_REGION}"
+  endpoint = "https://api.exoscale.ch/v1"
+  key = "${EXOSCALE_API_KEY}"
+  secret = "${EXOSCALE_API_SECRET}"
+EOF
+
+unset EXOSCALE_API_KEY EXOSCALE_API_SECRET
 ----
+<1> All lower case. For example `ch-dk-2`.

--- a/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
+++ b/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
@@ -1,11 +1,9 @@
 .Access to cloud API
 [source,bash]
 ----
-
 export EXOSCALE_API_KEY=<exoscale-key>
 export EXOSCALE_API_SECRET=<exoscale-secret>
 export EXOSCALE_ZONE=<exoscale-zone> <1>
-
 export EXOSCALE_S3_ENDPOINT="sos-${EXOSCALE_ZONE}.exo.io"
 ----
 <1> All lower case. For example `ch-dk-2`.

--- a/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
+++ b/docs/modules/ROOT/partials/exoscale/environment-vars.adoc
@@ -4,23 +4,8 @@
 
 export EXOSCALE_API_KEY=<exoscale-key>
 export EXOSCALE_API_SECRET=<exoscale-secret>
-export EXOSCALE_REGION=<exoscale-zone> <1>
+export EXOSCALE_ZONE=<exoscale-zone> <1>
 
-export EXOSCALE_CONFIG=$(pwd)/exoscale.toml
-export EXOSCALE_S3_ENDPOINT="sos-${EXOSCALE_REGION}.exo.io"
-
-cat <<EOF > "$EXOSCALE_CONFIG"
-defaultaccount = "cluster-setup"
-
-[[accounts]]
-  name = "cluster-setup"
-
-  defaultZone = "${EXOSCALE_REGION}"
-  endpoint = "https://api.exoscale.ch/v1"
-  key = "${EXOSCALE_API_KEY}"
-  secret = "${EXOSCALE_API_SECRET}"
-EOF
-
-unset EXOSCALE_API_KEY EXOSCALE_API_SECRET
+export EXOSCALE_S3_ENDPOINT="sos-${EXOSCALE_ZONE}.exo.io"
 ----
 <1> All lower case. For example `ch-dk-2`.


### PR DESCRIPTION
If using environment variables, a default zone can't be set and would have to be passed to every argument.

This PR writes the config to a temporary config file.

I had an issue where i tried creating an instance template in Zurich but my image was in Geneva which failed with a really unhelpful error.
