### PR TITLE
Fix Terraform command for creating hieradata in clouscale.ch install guide

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -300,7 +300,7 @@ module "cluster" {
   additional_worker_groups = {}
 }
 EOF
-terraform apply -target "module.cluster.module.lb.module.hiera.local_file.lb_hieradata"
+terraform apply -target "module.cluster.module.lb.module.hiera"
 ----
 
 . Review and merge the LB hieradata MR (listed in Terraform output `hieradata_mr`) and wait until the deploy pipeline after the merge is completed.


### PR DESCRIPTION
The old command confused Terraform: the command resulted in the correct plan but the subsequent apply ended with

```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

This commit adjusts the command to only target the whole vshn-lbaas-hieradata module resource, which should have the same
outcome, namely that the LB hieradata MR and resources it depends on are created.