### PR TITLE
Adjust cluster install how-tos for allowing custom cluster domain

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -69,6 +69,7 @@ export TF_VAR_lb_cloudscale_api_secret=<cloudscale-api-token-for-Floaty>
 
 include::partial$install/vshn-input.adoc[]
 
+[#_bootstrap_bucket]
 === Set up S3 bucket for cluster bootstrap
 
 . Create S3 bucket
@@ -107,6 +108,7 @@ mc mb --ignore-existing \
   "${CLUSTER_ID}/${CLUSTER_ID}-bootstrap-ignition"
 ----
 
+[#_upload_coreos_image]
 === Upload Red Hat CoreOS image
 
 . Export the Authorization header for the Cloudscale API.
@@ -176,6 +178,7 @@ curl -i -H "$AUTH_HEADER" \
   https://api.cloudscale.ch/v1/custom-images/import
 ----
 
+[#_set_vault_secrets]
 === Set secrets in Vault
 
 include::partial$connect-to-vault.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -263,21 +263,24 @@ Please look at the xref:oc4:ROOT:references/cloudscale/config.adoc[configuration
 If you use a custom "apps" domain, make sure to also change it in `parameters.openshift.appsDomain`.
 ====
 
+[#_compile_catalog]
+=== Commit changes and compile cluster catalog
 
-. Review and commit
+. Review changes.
+Have a look at the file `${CLUSTER_ID}.yml`.
+Override default parameters or add more component configurations as required for your cluster.
+
+. Commit changes
 +
 [source,bash]
 ----
-# Have a look at the file ${CLUSTER_ID}.yml.
-# Override any default parameters or add more component configuration.
-
 git commit -a -m "Setup cluster ${CLUSTER_ID}"
 git push
 
 popd
 ----
 
-. Compile and push Terraform setup
+. Compile and push cluster catalog
 +
 [source,bash]
 ----

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -225,9 +225,15 @@ include::partial$get-hieradata-token-from-vault.adoc[]
 
 include::partial$install/prepare-commodore.adoc[]
 
-=== OpenShift Installer Setup
+[#_configure_installer]
+=== Configure the OpenShift Installer
 
-include::partial$install/prepare-installer.adoc[]
+include::partial$install/configure-installer.adoc[]
+
+[#_run_installer]
+=== Run the OpenShift Installer
+
+include::partial$install/run-installer.adoc[]
 
 . Upload ignition config
 +

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -202,32 +202,41 @@ Most importantly you have the option to change node sizes or add additional spec
 Please look at the xref:oc4:ROOT:references/exoscale/config.adoc[configuration reference] for the available options.
 ====
 
-. Review and commit
+. Configure Exoscale-specific Terraform variables
 +
 [source,bash,subs="attributes+"]
 ----
-# Exoscale-specific config
 yq eval -i ".parameters.openshift4_terraform.terraform_variables.rhcos_template = \"${RHCOS_TEMPLATE}\"" \
   ${CLUSTER_ID}.yml
 yq eval -i ".parameters.openshift4_local_storage.local_storage_operator.channel = \"{ocp-minor-version}\"" \
   ${CLUSTER_ID}.yml <1>
+----
+<1> Can be removed as soon as Project Syn is Kubernetes version aware and we can set this automatically.
 
-# Have a look at the file ${CLUSTER_ID}.yml.
-# Override any default parameters or add more component configuration.
+[#_compile_catalog]
+=== Commit changes and compile cluster catalog
 
+. Review changes.
+Have a look at the file `${CLUSTER_ID}.yml`.
+Override default parameters or add more component configurations as required for your cluster.
+
+. Commit changes
++
+[source,bash]
+----
 git commit -a -m "Setup cluster ${CLUSTER_ID}"
 git push
 
 popd
 ----
-<1> Can be removed as soon as Project Syn is Kubernetes version aware and we can set this automatically.
 
-. Compile and push Terraform setup
+. Compile and push cluster catalog
 +
 [source,bash]
 ----
 commodore catalog compile ${CLUSTER_ID} --push -i
 ----
+
 
 === Provision Infrastructure
 

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -173,9 +173,15 @@ include::partial$get-hieradata-token-from-vault.adoc[]
 
 include::partial$install/prepare-commodore.adoc[]
 
-=== OpenShift Installer Setup
+[#_prepare_installer_config]
+=== Prepare OpenShift Installer Config
 
 include::partial$install/prepare-installer.adoc[]
+
+[#_run_installer]
+=== Run OpenShift Installer
+
+include::partial$install/run-installer.adoc[]
 
 . Upload ignition config
 +

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -55,6 +55,7 @@ include::partial$exoscale/environment-vars.adoc[]
 
 include::partial$install/vshn-input.adoc[]
 
+[#_create_iam_keys]
 === Create restricted Exoscale IAM keys for the LBs and object storage
 
 . Create restricted API keys
@@ -83,6 +84,7 @@ export TF_VAR_lb_exoscale_api_key=$(exo iam apikey show "${CLUSTER_ID}_floaty" \
   -O json | jq -r '.key')
 ----
 
+[#_bootstrap_bucket]
 === Set up S3 bucket for cluster bootstrap
 
 . Create S3 bucket
@@ -92,6 +94,7 @@ export TF_VAR_lb_exoscale_api_key=$(exo iam apikey show "${CLUSTER_ID}_floaty" \
 exo storage create "sos://${CLUSTER_ID}-bootstrap" --zone "${EXOSCALE_ZONE}"
 ----
 
+[#_upload_coreos_image]
 === Upload Red Hat CoreOS image
 
 . Fetch and convert the latest Red Hat CoreOS image
@@ -123,6 +126,7 @@ export RHCOS_TEMPLATE="rhcos-${RHCOS_VERSION}"
 ----
 
 
+[#_set_vault_secrets]
 === Set secrets in Vault
 
 include::partial$connect-to-vault.adoc[]

--- a/docs/modules/ROOT/partials/install/bootstrap-lb.adoc
+++ b/docs/modules/ROOT/partials/install/bootstrap-lb.adoc
@@ -13,7 +13,7 @@ done
 ----
 # Wait for Puppet provisioning to complete
 while true; do
-  curl --connect-timeout 1 "http://api.${CLUSTER_ID}.${BASE_DOMAIN}:6443"
+  curl --connect-timeout 1 "http://api.${CLUSTER_DOMAIN}:6443"
   if [ $? -eq 52 ]; then
     echo -e "\nHAproxy up"
     break

--- a/docs/modules/ROOT/partials/install/configure-installer.adoc
+++ b/docs/modules/ROOT/partials/install/configure-installer.adoc
@@ -1,16 +1,9 @@
-[CAUTION]
-These are the only steps which aren't idempotent and have to be completed uninterrupted in one go.
-If you have to recreate the install config or any of the generated manifests you need to rerun all of the subsequent steps.
+[TIP]
+====
+Starting with this section, we recommend that you change into a clean directory (for example a directory in your home).
+====
 
-[NOTE]
---
-You can add more options to the `install-config.yaml` file.
-Have a look at the https://docs.openshift.com/container-platform/{ocp-minor-version}/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal[config example] for more information.
-
-For example, you could change the SDN from a default value to something a customer requests due to some network requirements.
---
-
-. Prepare SSH key
+. Generate SSH key
 +
 [NOTE]
 ====
@@ -37,6 +30,14 @@ ssh-add $SSH_PRIVATE_KEY
 
 . Prepare `install-config.yaml`
 +
+[NOTE]
+--
+You can add more options to the `install-config.yaml` file.
+Have a look at the https://docs.openshift.com/container-platform/{ocp-minor-version}/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal[config example] for more information.
+
+For example, you could change the SDN from a default value to something a customer requests due to some network requirements.
+--
++
 [source,bash]
 ----
 export INSTALLER_DIR="$(pwd)/target"
@@ -56,6 +57,7 @@ pullSecret: |
 sshKey: "$(cat $SSH_PUBLIC_KEY)"
 EOF
 ----
+
 ifeval::["{provider}" == "cloudscale"]
 +
 . Cilium Optional: Add cilium
@@ -73,39 +75,3 @@ See https://github.com/projectsyn/component-cilium/blob/master/class/defaults.ym
 Verify with `less catalog/manifests/cilium/olm/*ciliumconfig.yaml`.
 ====
 endif::[]
-
-. Render install manifests (this will consume the `install-config.yaml`)
-+
-[source,bash]
-----
-openshift-install --dir "${INSTALLER_DIR}" \
-  create manifests
-----
-
-.. If you want to change the default "apps" domain for the cluster:
-+
-[source,bash]
-----
-yq w -i "${INSTALLER_DIR}/manifests/cluster-ingress-02-config.yml" \
-  spec.domain apps.example.com
-----
-ifeval::["{provider}" == "cloudscale"]
-+
-. Cilium Optional: Copy pre-rendered Cilium manifests
-+
-[%collapsible]
-====
-[source,bash]
-----
-cp catalog/manifests/cilium/olm/* target/manifests/
-----
-====
-endif::[]
-
-. Prepare install manifests and ignition config
-+
-[source,bash]
-----
-openshift-install --dir "${INSTALLER_DIR}" \
-  create ignition-configs
-----

--- a/docs/modules/ROOT/partials/install/finalize_part1.adoc
+++ b/docs/modules/ROOT/partials/install/finalize_part1.adoc
@@ -41,7 +41,7 @@ ifeval::["{provider}" == "exoscale"]
 [source,bash]
 ----
 for cname in "api" "apps"; do
-  exo dns add CNAME "${CLUSTER_ID}.${BASE_DOMAIN}" -n "_acme-challenge.${cname}" -a "${fulldomain}." -t 600
+  exo dns add CNAME "${CLUSTER_DOMAIN}" -n "_acme-challenge.${cname}" -a "${fulldomain}." -t 600
 done
 ----
 endif::[]

--- a/docs/modules/ROOT/partials/install/prepare-terraform.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-terraform.adoc
@@ -26,7 +26,7 @@ yq eval -i ".parameters.openshift.infraID = \"$(jq -r .infraID "${INSTALLER_DIR}
 yq eval -i ".parameters.openshift.clusterID = \"$(jq -r .clusterID "${INSTALLER_DIR}/metadata.json")\"" \
   ${CLUSTER_ID}.yml
 
-yq eval -i ".parameters.openshift.baseDomain = \"${CLUSTER_ID}.${BASE_DOMAIN}\"" \
+yq eval -i ".parameters.openshift.baseDomain = \"${CLUSTER_DOMAIN}\"" \
   ${CLUSTER_ID}.yml
 
 yq eval -i '.parameters.openshift.appsDomain = "apps.${openshift:baseDomain}"' \

--- a/docs/modules/ROOT/partials/install/run-installer.adoc
+++ b/docs/modules/ROOT/partials/install/run-installer.adoc
@@ -1,0 +1,47 @@
+[CAUTION]
+The steps in this section aren't idempotent and have to be completed uninterrupted in one go.
+If you have to recreate the install config or any of the generated manifests you need to rerun all of the subsequent steps.
+
+. Render install manifests (this will consume the `install-config.yaml`)
++
+[source,bash]
+----
+openshift-install --dir "${INSTALLER_DIR}" \
+  create manifests
+----
+
+.. If you want to change the default "apps" domain for the cluster:
++
+[source,bash]
+----
+yq w -i "${INSTALLER_DIR}/manifests/cluster-ingress-02-config.yml" \
+  spec.domain apps.example.com
+----
+
+ifeval::["{provider}" == "cloudscale"]
+. Cilium Optional: Copy pre-rendered Cilium manifests
++
+[%collapsible]
+====
+[source,bash]
+----
+cp catalog/manifests/cilium/olm/* target/manifests/
+----
+====
+endif::[]
+
+. Extract the cluster domain from the generated manifests
++
+[source,bash]
+----
+export CLUSTER_DOMAIN=$(yq e '.spec.baseDomain' \
+  "${INSTALLER_DIR}/manifests/cluster-dns-02-config.yml")
+----
+
+. Prepare install manifests and ignition config
++
+[source,bash]
+----
+openshift-install --dir "${INSTALLER_DIR}" \
+  create ignition-configs
+----


### PR DESCRIPTION
See commit messages for individual changes that are part of this PR.

Overall the goal is to make the install guides for cloudscale.ch and Exoscale easier to link to from other how-tos (e.g. https://github.com/appuio/appuio-io-docs/pull/76) which want to reuse the install guide but want to inject their own customizations.