### PR TITLE
Use kubectl patch to enable proxy protocol on the ingress controller

### DIFF
--- a/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
+++ b/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
@@ -109,6 +109,15 @@ for fqdn in "${LB_FQDNS[@]}"; do
 done
 ----
 
+. Enable the PROXY protocol on the ingresscontroller
++
+[source,bash]
+----
+kubectl -n openshift-ingress-operator patch \
+ingresscontrollers/default --type merge -p \
+'{"spec":{"endpointPublishingStrategy":{"type":"HostNetwork","hostNetwork":{"protocol":"PROXY"}}}}'
+----
+
 . Wait for installation to complete
 +
 [source,bash]


### PR DESCRIPTION
Proxy protocol on the cluster is only enabled once the cluster is synthesized. However the installation process gets stuck after bootstrapping the infra nodes, because ingress doesn't work (LBs already use proxy protocol).

This PR adds a manual step with kubectl patch that enables the proxy protocol on the ingress controller so the installation process can resume.