### PR TITLE
Update cloudscale install guide to OCP4.10

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -1,6 +1,6 @@
 = Installation on cloudscale.ch
 :ocp-minor-version: 4.10
-:ocp-patch-version: {ocp-minor-version}.6
+:ocp-patch-version: {ocp-minor-version}.3
 :provider: cloudscale
 
 [abstract]

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -1,6 +1,6 @@
 = Installation on cloudscale.ch
-:ocp-minor-version: 4.9
-:ocp-patch-version: {ocp-minor-version}.0
+:ocp-minor-version: 4.10
+:ocp-patch-version: {ocp-minor-version}.6
 :provider: cloudscale
 
 [abstract]


### PR DESCRIPTION
Installed as `c-frosty-frost-1818`. No OCP4.10 related problems found