### PR TITLE
Switch guides over to OIDC lieutenant login

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
@@ -101,7 +101,7 @@ curl -i -H "Authorization: Bearer ${CLOUDSCALE_TOKEN}" -X DELETE $(echo $respons
 ----
 # Vault login
 export VAULT_ADDR=https://vault-prod.syn.vshn.net
-vault login -method=ldap username=<your.name>
+vault login -method=oidc
 
 # delete token secret
 vault kv delete clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cloudscale

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -99,7 +99,7 @@ response=$(curl -sH "Authorization: Bearer ${CLOUDSCALE_TOKEN}" \
 +
 [source,bash]
 ----
-export REGION=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .facts.region)
+export REGION=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .facts.region)
 mc config host add \
   "${CLUSTER_ID}" "https://objects.${REGION}.cloudscale.ch" \
   $(echo $response | jq -r '.keys[0].access_key') \

--- a/docs/modules/ROOT/pages/how-tos/exoscale/decommission.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/decommission.adoc
@@ -44,7 +44,6 @@ export GITLAB_USER=<gitlab-user-name>
 # For example: https://api.syn.vshn.net
 # IMPORTANT: do NOT add a trailing `/`. Commands below will fail.
 export COMMODORE_API_URL=<lieutenant-api-endpoint>
-export COMMODORE_API_TOKEN=<lieutenant-api-token>
 
 export TF_VAR_lb_exoscale_api_key=irrelevant
 export TF_VAR_lb_exoscale_api_secret=irrelevant

--- a/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
+++ b/docs/modules/ROOT/pages/how-tos/recover-from-backup.adoc
@@ -63,7 +63,7 @@ git archive --remote ${REPO_URL} master | tar -xC catalog
 +
 [source,console]
 ----
-vault login -method=ldap username=<your username>
+vault login -method=oidc
 ----
 
 4. Export restic configuration

--- a/docs/modules/ROOT/partials/commodore-init.adoc
+++ b/docs/modules/ROOT/partials/commodore-init.adoc
@@ -3,11 +3,10 @@
 [source,bash]
 ----
 export COMMODORE_API_URL=https://api.syn.vshn.net <1>
-export COMMODORE_API_TOKEN=<your lieutenant token>
 
 # Set Project Syn cluster and tenant ID
 export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-cluster-id-1234
-export TENANT_ID=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
+export TENANT_ID=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
 ----
 <1> Replace with the API URL of the desired Lieutenant instance.
 

--- a/docs/modules/ROOT/partials/connect-to-vault.adoc
+++ b/docs/modules/ROOT/partials/connect-to-vault.adoc
@@ -2,5 +2,5 @@
 [source,bash]
 ----
 export VAULT_ADDR=https://vault-prod.syn.vshn.net
-vault login -method=ldap username=<your.name>
+vault login -method=oidc
 ----

--- a/docs/modules/ROOT/partials/install/prepare-commodore.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-commodore.adoc
@@ -12,7 +12,7 @@ Check https://syn.tools/commodore/running-commodore.html[Running Commodore] for 
 [source,bash]
 ----
 mkdir -p inventory/classes/
-git clone $(curl -sH"Authorization: Bearer ${COMMODORE_API_TOKEN}" "${COMMODORE_API_URL}/tenants/${TENANT_ID}" | jq -r '.gitRepo.url') inventory/classes/${TENANT_ID}
+git clone $(curl -sH"Authorization: Bearer $(commodore fetch-token)" "${COMMODORE_API_URL}/tenants/${TENANT_ID}" | jq -r '.gitRepo.url') inventory/classes/${TENANT_ID}
 ----
 
 ==== Cilium Optional: Prepare Cilium Configuration

--- a/docs/modules/ROOT/partials/install/registry-acl-fix.adoc
+++ b/docs/modules/ROOT/partials/install/registry-acl-fix.adoc
@@ -23,7 +23,7 @@ pip install awscli
 ----
 export AWS_ACCESS_KEY_ID=$(mc config host ls ${CLUSTER_ID} -json | jq -r .accessKey)
 export AWS_SECRET_ACCESS_KEY=$(mc config host ls ${CLUSTER_ID} -json | jq -r .secretKey)
-export REGION=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .facts.region)
+export REGION=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .facts.region)
 aws --endpoint-url "https://objects.${REGION}.cloudscale.ch" s3api get-public-access-block --bucket "${CLUSTER_ID}-image-registry"
 ----
 +

--- a/docs/modules/ROOT/partials/recovery/recover-etcd.adoc
+++ b/docs/modules/ROOT/partials/recovery/recover-etcd.adoc
@@ -50,18 +50,17 @@ The following CLI utilities need to be available locally:
 # For example: https://api.syn.vshn.net
 # IMPORTANT: do NOT add a trailing `/`. Commands below will fail.
 export COMMODORE_API_URL=<lieutenant-api-endpoint>
-export COMMODORE_API_TOKEN=<lieutenant-api-token>
 
 # Set Project Syn cluster and tenant ID
 export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-<something>
-export TENANT_ID=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
+export TENANT_ID=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
 ----
 
 .Fetch backup url from cluster repo
 
 [source,bash]
 ----
-GIT_REPO=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .gitRepo.url)
+GIT_REPO=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .gitRepo.url)
 git clone --depth 1 $GIT_REPO cluster-repo
 RESTIC_ENDPOINT=$(find cluster-repo/manifests/cluster-backup -name '*.yaml' -exec yq eval-all 'select(.kind == "Schedule" and .metadata.name == "etcd" ) | .spec.backend.s3.endpoint' {} \;)
 RESTIC_BUCKET=$(find cluster-repo/manifests/cluster-backup -name '*.yaml' -exec yq eval-all 'select(.kind == "Schedule" and .metadata.name == "etcd" ) | .spec.backend.s3.bucket' {} \;)

--- a/docs/modules/ROOT/partials/setup_terraform.adoc
+++ b/docs/modules/ROOT/partials/setup_terraform.adoc
@@ -21,7 +21,7 @@ alias terraform='docker run -it --rm \
   --ulimit memlock=-1 \
   "${tf_image}:${tf_tag}" /tf/terraform.sh'
 
-export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||; s|/|:|')
+export GITLAB_REPOSITORY_URL=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r '.gitRepo.url' | sed 's|ssh://||; s|/|:|')
 export GITLAB_REPOSITORY_NAME=${GITLAB_REPOSITORY_URL##*/}
 export GITLAB_CATALOG_PROJECT_ID=$(curl -sH "Authorization: Bearer ${GITLAB_TOKEN}" "https://git.vshn.net/api/v4/projects?simple=true&search=${GITLAB_REPOSITORY_NAME/.git}" | jq -r ".[] | select(.ssh_url_to_repo == \"${GITLAB_REPOSITORY_URL}\") | .id")
 export GITLAB_STATE_URL="https://git.vshn.net/api/v4/projects/${GITLAB_CATALOG_PROJECT_ID}/terraform/state/cluster"

--- a/docs/modules/ROOT/partials/vshn-input.adoc
+++ b/docs/modules/ROOT/partials/vshn-input.adoc
@@ -8,11 +8,10 @@ export GITLAB_USER=<gitlab-user-name>
 # For example: https://api.syn.vshn.net
 # IMPORTANT: do NOT add a trailing `/`. Commands below will fail.
 export COMMODORE_API_URL=<lieutenant-api-endpoint>
-export COMMODORE_API_TOKEN=<lieutenant-api-token>
 
 # Set Project Syn cluster and tenant ID
 export CLUSTER_ID=<lieutenant-cluster-id> # Looks like: c-<something>
-export TENANT_ID=$(curl -sH "Authorization: Bearer ${COMMODORE_API_TOKEN}" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
+export TENANT_ID=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
 ----
 
 ifeval::["{needs_hieradata_edit}" == "yes"]


### PR DESCRIPTION
I replaced `${COMMODORE_API_TOKEN}` with `$(commodore fetch-token)` to possibly allow for refresh token support.

The guide should be mostly backwards compatible if `commodore fetch-token)` returns the api token.