### PR TITLE
Fix directory locations in install guides

### DIFF
--- a/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
+++ b/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
@@ -161,6 +161,8 @@ endif::[]
 ----
 rm override.tf
 terraform apply
+
+popd
 ----
 
 . Approve worker certs

--- a/docs/modules/ROOT/partials/install/finalize_part1.adoc
+++ b/docs/modules/ROOT/partials/install/finalize_part1.adoc
@@ -91,6 +91,5 @@ You can find the password in the file `target/auth/kubeadmin-password` and the k
 +
 [source,bash]
 ----
-popd
 ls -l ${INSTALLER_DIR}/auth/
 ----

--- a/docs/modules/ROOT/partials/install/prepare-terraform.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-terraform.adoc
@@ -7,27 +7,6 @@
 TEAM=<team-name>
 ----
 
-. Bootstrap dynamic facts
-+
-[source,bash,subs="attributes+"]
-----
-yq eval -i ".parameters.dynamic_facts.kubernetesVersion.major = \"$(echo "{k8s-minor-version}" | awk -F. '{print $1}')\"" \
-  ${CLUSTER_ID}.yml
-yq eval -i ".parameters.dynamic_facts.kubernetesVersion.minor = \"$(echo "{k8s-minor-version}" | awk -F. '{print $2}')\"" \
-  ${CLUSTER_ID}.yml
-
-yq eval -i ".parameters.dynamic_facts.openshiftVersion.Major = \"$(echo "{ocp-minor-version}" | awk -F. '{print $1}')\"" \
-  ${CLUSTER_ID}.yml
-yq eval -i ".parameters.dynamic_facts.openshiftVersion.Minor = \"$(echo "{ocp-minor-version}" | awk -F. '{print $2}')\"" \
-  ${CLUSTER_ID}.yml
-----
-+
-[NOTE]
---
-Some components rely on dynamic facts fetched from the cluster at runtime.
-Those facts aren't available before Steward is installed on the cluster.
---
-
 . Prepare Terraform cluster config
 +
 [source,bash,subs="attributes+"]
@@ -99,5 +78,26 @@ yq eval -i ".parameters.vshnLdap.serviceId = \"${LDAP_ID}\"" \
 yq eval -i ".parameters.openshift4_terraform.gitlab_ci.git.username = \"GitLab CI\"" \
   ${CLUSTER_ID}.yml
 yq eval -i ".parameters.openshift4_terraform.gitlab_ci.git.email = \"tech+${CLUSTER_ID}@vshn.ch\"" \
+  ${CLUSTER_ID}.yml
+----
+
+. Bootstrap dynamic facts
++
+[NOTE]
+--
+Some components rely on dynamic facts fetched from the cluster at runtime.
+Those facts aren't available before Steward is installed on the cluster.
+--
++
+[source,bash,subs="attributes+"]
+----
+yq eval -i ".parameters.dynamic_facts.kubernetesVersion.major = \"$(echo "{k8s-minor-version}" | awk -F. '{print $1}')\"" \
+  ${CLUSTER_ID}.yml
+yq eval -i ".parameters.dynamic_facts.kubernetesVersion.minor = \"$(echo "{k8s-minor-version}" | awk -F. '{print $2}')\"" \
+  ${CLUSTER_ID}.yml
+
+yq eval -i ".parameters.dynamic_facts.openshiftVersion.Major = \"$(echo "{ocp-minor-version}" | awk -F. '{print $1}')\"" \
+  ${CLUSTER_ID}.yml
+yq eval -i ".parameters.dynamic_facts.openshiftVersion.Minor = \"$(echo "{ocp-minor-version}" | awk -F. '{print $2}')\"" \
   ${CLUSTER_ID}.yml
 ----


### PR DESCRIPTION
- Moves `popd` out of Terraform directory to after the last Terraform command.
- Create dynamic facts after moving to the tenant repo.
