### PR TITLE
Specify dynamic facts in Commodore command line for early install catalog compilation

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -275,10 +275,7 @@ popd
 
 . Compile and push cluster catalog
 +
-[source,bash]
-----
-commodore catalog compile ${CLUSTER_ID} --push -i
-----
+include::partial$install/commodore-dynfacts.adoc[]
 
 === Provision Infrastructure
 

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -220,10 +220,7 @@ popd
 
 . Compile and push cluster catalog
 +
-[source,bash]
-----
-commodore catalog compile ${CLUSTER_ID} --push -i
-----
+include::partial$install/commodore-dynfacts.adoc[]
 
 
 === Provision Infrastructure

--- a/docs/modules/ROOT/partials/install/commodore-dynfacts.adoc
+++ b/docs/modules/ROOT/partials/install/commodore-dynfacts.adoc
@@ -1,0 +1,12 @@
+[source,bash,subs="attributes+"]
+----
+commodore catalog compile ${CLUSTER_ID} --push -i \
+  --dynamic-fact kubernetesVersion.major=$(echo "{k8s-minor-version}" | awk -F. '{print $1}') \
+  --dynamic-fact kubernetesVersion.minor=$(echo "{k8s-minor-version}" | awk -F. '{print $2}') \
+  --dynamic-fact openshiftVersion.Major=$(echo "{ocp-minor-version}" | awk -F. '{print $1}') \
+  --dynamic-fact openshiftVersion.Minor=$(echo "{ocp-minor-version}" | awk -F. '{print $2}')
+----
++
+[NOTE]
+This `commodore` call requires Commodore v1.5.0 or newer.
+Please make sure to update your local installation.

--- a/docs/modules/ROOT/partials/install/finalize_part1.adoc
+++ b/docs/modules/ROOT/partials/install/finalize_part1.adoc
@@ -4,19 +4,6 @@
 
 . https://kb.vshn.ch/vshnsyn/how-tos/synthesize.html[Make the cluster Project Syn enabled]
 
-. Remove bootstrap dynamic facts
-+
-[source,bash]
-----
-pushd "inventory/classes/${TENANT_ID}/"
-
-yq eval -i "del(.parameters.dynamic_facts)" ${CLUSTER_ID}.yml
-
-git commit -a -m "Remove bootstrapping dynamic_facts"
-git push
-popd
-----
-
 === Setup acme-dns CNAME records for the cluster
 
 NOTE: You can skip this section if you're not using Let's Encrypt for the cluster's API and default wildcard certificates.

--- a/docs/modules/ROOT/partials/install/prepare-commodore.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-commodore.adoc
@@ -39,9 +39,6 @@ popd
 +
 . Compile catalog
 +
-[source,bash]
-----
-commodore catalog compile ${CLUSTER_ID} --push -i
-----
+include::partial$install/commodore-dynfacts.adoc[]
 ====
 endif::[]

--- a/docs/modules/ROOT/partials/install/prepare-terraform.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-terraform.adoc
@@ -69,27 +69,6 @@ yq eval -i ".parameters.openshift.appsDomain = \"${APPS_DOMAIN}\"" \
 ----
 ====
 
-. Bootstrap dynamic facts
-+
-[NOTE]
---
-Some components rely on dynamic facts fetched from the cluster at runtime.
-Those facts aren't available before Steward is installed on the cluster.
---
-+
-[source,bash,subs="attributes+"]
-----
-yq eval -i ".parameters.dynamic_facts.kubernetesVersion.major = \"$(echo "{k8s-minor-version}" | awk -F. '{print $1}')\"" \
-  ${CLUSTER_ID}.yml
-yq eval -i ".parameters.dynamic_facts.kubernetesVersion.minor = \"$(echo "{k8s-minor-version}" | awk -F. '{print $2}')\"" \
-  ${CLUSTER_ID}.yml
-
-yq eval -i ".parameters.dynamic_facts.openshiftVersion.Major = \"$(echo "{ocp-minor-version}" | awk -F. '{print $1}')\"" \
-  ${CLUSTER_ID}.yml
-yq eval -i ".parameters.dynamic_facts.openshiftVersion.Minor = \"$(echo "{ocp-minor-version}" | awk -F. '{print $2}')\"" \
-  ${CLUSTER_ID}.yml
-----
-
 ifeval::["{provider}" == "exoscale"]
 . Configure Exoscale-specific Terraform variables
 +


### PR DESCRIPTION
We added support for providing dynamic facts on the command line for `commodore catalog compile` in https://github.com/projectsyn/commodore/pull/565.

This commit updates the OpenShift 4 installation instructions to use this flag instead of adding dynamic facts in the cluster config.