### PR TITLE
Use qcow2 format for custom image import and delete bootstrap bucket

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -45,7 +45,6 @@ It's currently very specific to VSHN and needs further changes to be more generi
 * `yq` https://mikefarah.gitbook.io/yq[yq YAML processor] (version 4 or higher)
 * `openshift-install` (direct download: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-{ocp-minor-version}/openshift-install-linux.tar.gz[linux], https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-{ocp-minor-version}/openshift-install-mac.tar.gz[macOS])
 * `vault` https://www.vaultproject.io/docs/commands[Vault CLI]
-* `qemu-img`
 * `curl`
 * `gzip`
 
@@ -137,20 +136,19 @@ curl -sH "$AUTH_HEADER" https://api.cloudscale.ch/v1/custom-images | jq -r '.[] 
 If a URL is printed to the output, you can skip the next steps and directly jump to the next section.
 ====
 
-. Fetch and convert the latest Red Hat CoreOS image
+. Fetch the latest Red Hat CoreOS image
 +
 [source,bash,subs="attributes+"]
 ----
-curl -L https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{ocp-minor-version}/{ocp-patch-version}/rhcos-{ocp-patch-version}-x86_64-openstack.x86_64.qcow2.gz | gzip -d > rhcos-{ocp-minor-version}.qcow
-qemu-img convert rhcos-{ocp-minor-version}.qcow rhcos-{ocp-minor-version}.raw
+curl -L https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{ocp-minor-version}/{ocp-patch-version}/rhcos-{ocp-patch-version}-x86_64-openstack.x86_64.qcow2.gz | gzip -d > rhcos-{ocp-minor-version}.qcow2
 ----
 
 . Upload the image to S3 and make it public
 +
 [source,bash,subs="attributes+"]
 ----
-mc cp rhcos-{ocp-minor-version}.raw "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/"
-mc policy set download "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.raw"
+mc cp rhcos-{ocp-minor-version}.qcow2 "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/"
+mc policy set download "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.qcow2"
 ----
 +
 [TIP]
@@ -159,14 +157,14 @@ You can check that the download policy is applied successfully with
 
 [source,bash,subs="attributes+"]
 ----
-mc policy get "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.raw"
+mc policy get "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.qcow2"
 ----
 
 The output should be
 
 [source,subs="attributes+"]
 ----
-`Access permission for `[…]-bootstrap-ignition/rhcos-{ocp-minor-version}.raw` is `download``
+`Access permission for `[…]-bootstrap-ignition/rhcos-{ocp-minor-version}.qcow2` is `download``
 ----
 ====
 
@@ -175,13 +173,30 @@ The output should be
 [source,bash,subs="attributes+"]
 ----
 curl -i -H "$AUTH_HEADER" \
-  -F url="$(mc share download --json "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.raw" | jq -r .url)" \
+  -F url="$(mc share download --json "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.qcow2" | jq -r .url)" \
   -F name='RHCOS {ocp-minor-version}' \
   -F zones="${REGION}1" \
   -F slug=rhcos-{ocp-minor-version} \
-  -F source_format=raw \
+  -F source_format=qcow2 \
   -F user_data_handling=pass-through \
   https://api.cloudscale.ch/v1/custom-images/import
+----
+
+. Wait for custom image import to complete
++
+[source,bash,subs="attributes+"]
+----
+while [ "$(curl -s -H $AUTH_HEADER https://api.cloudscale.ch/v1/custom-images/import | jq -r '.[].status')" != "success" ]; do
+    echo -n "."
+    sleep 5
+done && echo -e "\nCustom image import successful"
+----
+
+. Delete the image from S3
++
+[source,bash,subs="attributes+"]
+----
+mc rm "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.qcow2"
 ----
 
 [#_set_vault_secrets]

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -182,23 +182,6 @@ curl -i -H "$AUTH_HEADER" \
   https://api.cloudscale.ch/v1/custom-images/import
 ----
 
-. Wait for custom image import to complete
-+
-[source,bash,subs="attributes+"]
-----
-while [ "$(curl -s -H $AUTH_HEADER https://api.cloudscale.ch/v1/custom-images/import | jq -r '.[].status')" != "success" ]; do
-    echo -n "."
-    sleep 5
-done && echo -e "\nCustom image import successful"
-----
-
-. Delete the image from S3
-+
-[source,bash,subs="attributes+"]
-----
-mc rm "$\{CLUSTER_ID\}/$\{CLUSTER_ID\}-bootstrap-ignition/rhcos-{ocp-minor-version}.qcow2"
-----
-
 [#_set_vault_secrets]
 === Set secrets in Vault
 
@@ -361,3 +344,10 @@ include::partial$install/finalize_part1.adoc[]
 include::partial$install/registry-acl-fix.adoc[]
 
 include::partial$install/finalize_part2.adoc[]
++
+. Remove bootstrap bucket
+[source,bash]
+----
+mc rm -r --force "${CLUSTER_ID}/${CLUSTER_ID}-bootstrap-ignition"
+mc rb "${CLUSTER_ID}/${CLUSTER_ID}-bootstrap-ignition"
+----


### PR DESCRIPTION
cloudscale.ch now supports custom image import in qcow2 format. There's no need anymore to convert the image to `raw` and you only need to upload a ~2.5G file to S3 instead of 16G for the raw image.

Also add steps to delete the file from the bucket after the cutom image is successfully imported