### PR TITLE
Use cluster-admin to drain nodes, add wait timeout

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/update_compute_flavors.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/update_compute_flavors.adoc
@@ -138,7 +138,7 @@ sed -i '/^resource "cloudscale_server" "lb"/a   allow_stopping_for_update = true
 +
 [source,bash]
 ----
-terraform state list module.cluster.module.master.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc adm uncordon $name; oc wait node --all --for condition=ready; done; done
+terraform state list module.cluster.module.master.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait node --all --for condition=ready; done; done
 ----
 
 === Update infra nodes
@@ -146,7 +146,7 @@ terraform state list module.cluster.module.master.cloudscale_server.node | while
 +
 [source,bash]
 ----
-terraform state list module.cluster.module.infra.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc adm uncordon $name; oc wait node --all --for condition=ready; done; done
+terraform state list module.cluster.module.infra.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait node --all --for condition=ready; done; done
 ----
 
 === Update worker nodes
@@ -154,7 +154,7 @@ terraform state list module.cluster.module.infra.cloudscale_server.node | while 
 +
 [source,bash]
 ----
-terraform state list module.cluster.module.worker.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc adm uncordon $name; oc wait node --all --for condition=ready; done; done
+terraform state list module.cluster.module.worker.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait node --all --for condition=ready; done; done
 ----
 
 === Update storage nodes
@@ -164,9 +164,9 @@ terraform state list module.cluster.module.worker.cloudscale_server.node | while
 ----
 terraform state list 'module.cluster.module.additional_worker["storage"].cloudscale_server.node' | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0]'; echo $node; done
 # For each of the storage nodes do:
-oc adm drain $name --delete-emptydir-data --ignore-daemonsets --force
+oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force
 terraform apply -target $node -auto-approve
-oc adm uncordon $name
+oc --as=cluster-admin adm uncordon $name
 # Now make sure storage cluster is healthy and proceed with the next node
 ----
 
@@ -181,5 +181,5 @@ terraform apply -target 'module.cluster.module.lb.cloudscale_server.lb[1]' -auto
 ----
 
 === Cleanup
-. Run the Terraform CI/CD pipeline in cluster catalog, verify plan output and make sure `allow_stopping_for_update = true` gets removed from the Terraform state. 
+. Run the Terraform CI/CD pipeline in cluster catalog, verify plan output and make sure `allow_stopping_for_update = true` gets removed from the Terraform state.
 . Apply the Terraform plan if there are no unexpected changes.

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/update_compute_flavors.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/update_compute_flavors.adoc
@@ -138,7 +138,7 @@ sed -i '/^resource "cloudscale_server" "lb"/a   allow_stopping_for_update = true
 +
 [source,bash]
 ----
-terraform state list module.cluster.module.master.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait node --all --for condition=ready; done; done
+terraform state list module.cluster.module.master.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait --timeout=300s node --all --for condition=ready; done; done
 ----
 
 === Update infra nodes
@@ -146,7 +146,7 @@ terraform state list module.cluster.module.master.cloudscale_server.node | while
 +
 [source,bash]
 ----
-terraform state list module.cluster.module.infra.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait node --all --for condition=ready; done; done
+terraform state list module.cluster.module.infra.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait --timeout=300s node --all --for condition=ready; done; done
 ----
 
 === Update worker nodes
@@ -154,7 +154,7 @@ terraform state list module.cluster.module.infra.cloudscale_server.node | while 
 +
 [source,bash]
 ----
-terraform state list module.cluster.module.worker.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait node --all --for condition=ready; done; done
+terraform state list module.cluster.module.worker.cloudscale_server.node | while read node; do terraform show -json | jq --raw-output --arg node "$node" '.values.root_module.child_modules[].child_modules[].resources[] | select(.address == $node) | .values.name | split(".")[0] ' | while read name; do oc --as=cluster-admin adm drain $name --delete-emptydir-data --ignore-daemonsets --force; terraform apply -target $node -auto-approve; oc --as=cluster-admin adm uncordon $name; oc wait --timeout=300s node --all --for condition=ready; done; done
 ----
 
 === Update storage nodes


### PR DESCRIPTION
- `oc as=cluster-admin` for node drains, otherwise the commands will just happily ignore the drain and run terraform apply without draining
- add a 5min timeout for the `oc wait` for nodes being ready. It's not strictly necessary because some poddisruptionbudgets will prevent the next node drain anyway, but it reduces noise in the output