### PR TITLE
Improve section on `oc create token` in OCP 4.11 release notes

### DIFF
--- a/docs/modules/ROOT/pages/references/release_notes.adoc
+++ b/docs/modules/ROOT/pages/references/release_notes.adoc
@@ -56,7 +56,7 @@ Conditional updates::
 
 OpenShift always only listed newer versions available to the cluster.
 Available means, it's safe to update to that version.
-OpenShift 4.11 on the Web Console no explains the risks of a certain update.
+OpenShift 4.11 on the Web Console now explains the risks of a certain update.
 Cluster administrators can then decide to do the update anyway and accept that risk.
 
 Web Console integrated observability::


### PR DESCRIPTION
Add a callout noting that `oc create token` generates tokens which expire (the default lifetime appears to be 1h), and point users to the Kubernetes docs for creating a SA API token secret if they need a token which doesn't have a limited lifetime.