### PR TITLE
Default new installations to `baselineCapabilitySet: v4.11`

### DIFF
--- a/docs/modules/ROOT/partials/install/configure-installer.adoc
+++ b/docs/modules/ROOT/partials/install/configure-installer.adoc
@@ -55,6 +55,8 @@ networking:
 pullSecret: |
   ${PULL_SECRET}
 sshKey: "$(cat $SSH_PUBLIC_KEY)"
+capabilities:
+  baselineCapabilitySet: v4.11
 EOF
 ----
 


### PR DESCRIPTION
We explicitly default new installations to `baselineCapabilitySet` `v4.11`. That way we ensure that new optional components of future releases won't be installed automatically.