### PR TITLE
Update install instructions for Exoscale

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -37,7 +37,7 @@ include::partial$install/prerequisites.adoc[]
 * `virt-edit`
 * `cpio`
 //* Clone of the https://github.com/appuio/terraform-openshift4-exoscale[terraform-openshift4-exoscale] repository
-* `exo` >= v1.37.0 https://community.exoscale.com/documentation/tools/exoscale-command-line-interface[Exoscale CLI]
+* `exo` >= v1.48.0 https://community.exoscale.com/documentation/tools/exoscale-command-line-interface[Exoscale CLI]
 * An unrestricted Exoscale https://community.exoscale.com/documentation/iam/quick-start/#api-keys[API key]
 * https://community.exoscale.com/documentation/dns/quick-start/#subscribing-to-the-service[DNS subscription] activated in the Exoscale organisation
 
@@ -59,30 +59,14 @@ include::partial$install/vshn-input.adoc[]
 [#_create_iam_keys]
 === Create restricted Exoscale IAM keys for the LBs and object storage
 
-. Create restricted API keys
+. Create restricted API key for Exoscale object storage
 +
-.Restricted API key for object storage
 [source,bash]
 ----
-export EXOSCALE_S3_SECRETKEY=$(exo iam apikey create "${CLUSTER_ID}_object_storage" \
-  -o 'sos/*' -O json | jq -r '.secret')
-export EXOSCALE_S3_ACCESSKEY=$(exo iam apikey show "${CLUSTER_ID}_object_storage" \
-  -O json | jq -r '.key')
-----
-+
-.Restricted API key for the LBs
-[source,bash]
-----
-export TF_VAR_lb_exoscale_api_secret=$(exo iam apikey create "${CLUSTER_ID}_floaty" \
-  -o 'compute/addIpToNic' \
-  -o 'compute/listNics' \
-  -o 'compute/listResourceDetails' \
-  -o 'compute/listVirtualMachines' \
-  -o 'compute/queryAsyncJobResult' \
-  -o 'compute/removeIpFromNic' \
-  -O json | jq -r '.secret')
-export TF_VAR_lb_exoscale_api_key=$(exo iam apikey show "${CLUSTER_ID}_floaty" \
-  -O json | jq -r '.key')
+exoscale_s3_credentials=$(exo iam access-key create "${CLUSTER_ID}_object_storage" \
+  --tag sos -O json)
+export EXOSCALE_S3_ACCESSKEY=$(echo "${exoscale_s3_credentials}" | jq -r '.api_key')
+export EXOSCALE_S3_SECRETKEY=$(echo "${exoscale_s3_credentials}" | jq -r '.api_secret')
 ----
 
 [#_bootstrap_bucket]
@@ -139,11 +123,6 @@ include::partial$connect-to-vault.adoc[]
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/exoscale/storage_iam \
   s3_access_key=${EXOSCALE_S3_ACCESSKEY} \
   s3_secret_key=${EXOSCALE_S3_SECRETKEY}
-
-# Put LB API key in Vault
-vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/floaty \
-  iam_key=${TF_VAR_lb_exoscale_api_key} \
-  iam_secret=${TF_VAR_lb_exoscale_api_secret}
 
 # Generate an HTTP secret for the registry
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/registry \

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -220,6 +220,21 @@ EOF
 terraform apply
 ----
 
+. Set Exoscale Elastic IP reverse DNS
++
+[source,bash]
+----
+terraform state pull > state.json
+
+ingress_id=$(jq -r '.resources[] | select(.type == "exoscale_elastic_ip" and .name == "ingress") | .instances[0].attributes.id' state.json)
+api_id=$(jq -r '.resources[] | select(.type == "exoscale_elastic_ip" and .name == "api") | .instances[0].attributes.id' state.json)
+# Use auto-generated Exoscale API V2 OpenAPI command to set EIP reverse DNS
+echo "{\"domain-name\": \"ingress.${CLUSTER_DOMAIN}.\"}" | exo x update-reverse-dns-elastic-ip "$ingress_id"
+echo "{\"domain-name\": \"api.${CLUSTER_DOMAIN}.\"}" | exo x update-reverse-dns-elastic-ip "$api_id"
+
+rm state.json
+----
+
 . Create LB hieradata
 +
 [source,bash]

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -180,6 +180,12 @@ include::partial$install/prepare-terraform.adoc[]
 . Review changes.
 Have a look at the file `${CLUSTER_ID}.yml`.
 Override default parameters or add more component configurations as required for your cluster.
++
+[IMPORTANT]
+====
+Ensure that you're using component `openshift4-terraform` v5.0.0 or newer.
+Otherwise the instructions in this how-to might not apply.
+====
 
 . Commit changes
 +

--- a/docs/modules/ROOT/partials/exoscale/configure-terraform-secrets.adoc
+++ b/docs/modules/ROOT/partials/exoscale/configure-terraform-secrets.adoc
@@ -5,8 +5,6 @@
 cat <<EOF > ./terraform.env
 EXOSCALE_API_KEY
 EXOSCALE_API_SECRET
-TF_VAR_lb_exoscale_api_key
-TF_VAR_lb_exoscale_api_secret
 TF_VAR_control_vshn_net_token
 GIT_AUTHOR_NAME
 GIT_AUTHOR_EMAIL

--- a/docs/modules/ROOT/partials/install/bootstrap-lb.adoc
+++ b/docs/modules/ROOT/partials/install/bootstrap-lb.adoc
@@ -13,7 +13,7 @@ done
 ----
 # Wait for Puppet provisioning to complete
 while true; do
-  curl --connect-timeout 1 "http://api.${CLUSTER_DOMAIN}:6443"
+  curl --connect-timeout 1 "http://api.${CLUSTER_DOMAIN}:6443" &>/dev/null
   if [ $? -eq 52 ]; then
     echo -e "\nHAproxy up"
     break

--- a/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
+++ b/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
@@ -56,7 +56,9 @@ EOF
 terraform apply
 ----
 
+ifeval::["{provider}" == "cloudscale"]
 . Add the DNS records for etcd shown in output variable `dns_entries` from the previous step to the cluster's parent zone
+endif::[]
 
 . Wait for bootstrap to complete
 +


### PR DESCRIPTION
* Update instructions to use new `exo iam access-key` command
* Remove creation of Floaty access-key, since that is now managed by Terraform
* Add commands to set Elastic IP reverse DNS until the new Terraform resource gains support to configure reverse DNS (https://github.com/exoscale/terraform-provider-exoscale/issues/188)