### PR TITLE
Create LB and all machines security groups with `terraform apply -target`

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -223,8 +223,12 @@ module "cluster" {
   additional_worker_groups = {}
 }
 EOF
+terraform apply -target module.cluster.exoscale_security_group.all_machines
+terraform apply -target module.cluster.module.lb.exoscale_security_group.load_balancers
 terraform apply
 ----
++
+NOTE: We create the LB and all machines security group with `terraform apply -target` to avoid a bug in the Exoscale Terraform provider when trying to create security group rules which reference security groups which aren't created yet.
 
 . Set Exoscale Elastic IP reverse DNS
 +


### PR DESCRIPTION
This is necessary to avoid a bug in the Exoscale Terraform provider which results in errors like

```
╷
│ Error: Provider produced inconsistent final plan
│
│ When expanding the plan for module.cluster.module.lb.exoscale_security_group_rule.load_balancers_machine_config_server[0] to include new values learned so far during apply, provider "registry.terraform.io/exoscale/exoscale" produced an invalid new value for
│ .user_security_group_id: was null, but now cty.StringVal("5f5f94d2-b9b7-49a4-b06f-f9f40e59e461").
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```