### PR TITLE
Remove step to explicitly enable billing metrics collection

### DIFF
--- a/docs/modules/ROOT/partials/install/prepare-commodore.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-commodore.adoc
@@ -32,15 +32,9 @@ yq eval -i '.parameters.openshift.infraID = "TO_BE_DEFINED"' ${CLUSTER_ID}.yml
 yq eval -i '.parameters.openshift.clusterID = "TO_BE_DEFINED"' ${CLUSTER_ID}.yml
 
 git commit -a -m "Add Cilium addon to ${CLUSTER_ID}"
+
 git push
 popd
-----
-+
-. Enable billing metrics collection
-+
-[source,bash]
-----
-yq eval -i '.classes' += ["global.distribution.openshift4.appuio-managed-billing"] ${CLUSTER_ID}.yml
 ----
 
 . Compile catalog


### PR DESCRIPTION
Billing metrics collection is now enabled in the Commodore global defaults, so we don't need to explicitly enable it on each new cluster anymore.