### PR TITLE
Add note in install how-to to check samples operator

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -328,6 +328,9 @@ oc create secret generic image-registry-private-configuration-user \
 --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=$(mc config host ls ${CLUSTER_ID} -json | jq -r .accessKey) \
 --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=$(mc config host ls ${CLUSTER_ID} -json | jq -r .secretKey)
 ----
++
+include::partial$install/registry-samples-operator.adoc[]
+
 include::partial$install/finalize_part1.adoc[]
 
 include::partial$install/registry-acl-fix.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -294,6 +294,8 @@ oc create secret generic image-registry-private-configuration-user \
 --from-literal=REGISTRY_STORAGE_S3_ACCESSKEY=${EXOSCALE_S3_ACCESSKEY} \
 --from-literal=REGISTRY_STORAGE_S3_SECRETKEY=${EXOSCALE_S3_SECRETKEY}
 ----
++
+include::partial$install/registry-samples-operator.adoc[]
 
 include::partial$install/finalize_part1.adoc[]
 

--- a/docs/modules/ROOT/partials/install/registry-samples-operator.adoc
+++ b/docs/modules/ROOT/partials/install/registry-samples-operator.adoc
@@ -1,0 +1,22 @@
+[NOTE]
+====
+If the registry S3 credentials are created too long after the initial cluster setup, it's possible that the `openshift-samples` operator has disabled itself because it couldn't find a working in-cluster registry.
+
+If the samples operator is disabled, no templates and builder images will be available on the cluster.
+
+You can check the samples-operator's state with the following command:
+
+[source,bash]
+----
+kubectl get config.samples cluster -ojsonpath='{.spec.managementState}'
+----
+
+If the command returns `Removed`, verify that the in-cluster registry pods are now running, and enable the samples operator again:
+
+[source,bash]
+----
+kubectl patch config.samples cluster -p '{"spec":{"managementState":"Managed"}}'
+----
+
+See the https://docs.openshift.com/container-platform/latest/openshift_images/configuring-samples-operator.html[upstream documentation] for more details on the samples operator.
+====


### PR DESCRIPTION
We've found that the samples operator can disable itself if the in-cluster container registry isn't available for too long after the initial cluster setup.

This commit adds a note in the step where we configure registry S3 credentials to check on the samples operator.