### PR TITLE
Fix small issues in install instructions

### DIFF
--- a/docs/modules/ROOT/pages/explanations/decisions/machine-api.adoc
+++ b/docs/modules/ROOT/pages/explanations/decisions/machine-api.adoc
@@ -143,7 +143,7 @@ The disadvantage over option one is that we would lose additional features such 
 
 ==== Design
 
-===== Cloudscale.ch Cloud Provider
+===== cloudscale.ch Cloud Provider
 
 We need to implement the interface for the upstream autoscaler to interact with cloudscale.ch.
 We should most likely implement this as a https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/externalgrpc[gRPC service].

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -30,6 +30,8 @@ It's currently very specific to VSHN and needs further changes to be more generi
 
 * You already have a Tenant and its git repository
 * You have a CCSP Red Hat login and are logged into https://cloud.redhat.com/openshift/install/metal/user-provisioned[Red Hat Openshift Cluster Manager]
++
+IMPORTANT: Don't use your personal account to login to the cluster manager for installation.
 * You want to register a new cluster in Lieutenant and are about to install Openshift 4 on cloudscale.ch
 
 == Prerequisites

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -340,6 +340,7 @@ include::partial$install/registry-acl-fix.adoc[]
 include::partial$install/finalize_part2.adoc[]
 +
 . Remove bootstrap bucket
++
 [source,bash]
 ----
 mc rm -r --force "${CLUSTER_ID}/${CLUSTER_ID}-bootstrap-ignition"

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -30,7 +30,7 @@ It's currently very specific to VSHN and needs further changes to be more generi
 
 * You already have a Tenant and its git repository
 * You have a CCSP Red Hat login and are logged into https://cloud.redhat.com/openshift/install/metal/user-provisioned[Red Hat Openshift Cluster Manager]
-* You want to register a new cluster in Lieutenant and are about to install Openshift 4 on Cloudscale
+* You want to register a new cluster in Lieutenant and are about to install Openshift 4 on cloudscale.ch
 
 == Prerequisites
 
@@ -100,7 +100,7 @@ mc mb --ignore-existing \
 [#_upload_coreos_image]
 === Upload Red Hat CoreOS image
 
-. Export the Authorization header for the Cloudscale API.
+. Export the Authorization header for the cloudscale.ch API.
 +
 [source,bash]
 ----
@@ -110,7 +110,7 @@ export AUTH_HEADER="Authorization: Bearer ${CLOUDSCALE_API_TOKEN}"
 [NOTE]
 ====
 The variable `CLOUDSCALE_API_TOKEN` could be used directly.
-Exporting the variable `AUTH_HEADER` is done to be compatible with the https://www.cloudscale.ch/en/api/[Cloudscale API documentation].
+Exporting the variable `AUTH_HEADER` is done to be compatible with the https://www.cloudscale.ch/en/api/[cloudscale.ch API documentation].
 ====
 
 . Check if image already exists in the correct zone
@@ -157,7 +157,7 @@ The output should be
 ----
 ====
 
-. Import the image to Cloudscale
+. Import the image to cloudscale.ch
 +
 [source,bash,subs="attributes+"]
 ----

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/remove_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/remove_node.adoc
@@ -14,7 +14,7 @@ Steps to remove a worker node of an OpenShift 4 cluster on https://cloudscale.ch
 
 == Starting situation
 
-* You already have a OpenShift 4 cluster on Cloudscale
+* You already have a OpenShift 4 cluster on cloudscale.ch
 * You have admin-level access to the cluster
 * You want to remove an existing worker node in the cluster
 

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -23,6 +23,8 @@ It's currently very specific to VSHN and needs further changes to be more generi
 
 * You already have a Tenant and its Git repository
 * You have a CCSP Red Hat login and are logged into https://cloud.redhat.com/openshift/install/metal/user-provisioned[Red Hat Openshift Cluster Manager]
++
+IMPORTANT: Don't use your personal account to login to the cluster manager for installation.
 * You want to register a new cluster in Lieutenant and are about to install Openshift 4 on Exoscale
 
 == Prerequisites

--- a/docs/modules/ROOT/pages/how-tos/generic-pre-install-checklist.adoc
+++ b/docs/modules/ROOT/pages/how-tos/generic-pre-install-checklist.adoc
@@ -26,7 +26,7 @@ Once setup, this allows us to progress with the cluster setup and management wit
 For clusters on Exoscale the Exoscale DNS service is used.
 Ask the customer to set the corresponding NS record when reaching that step within the setup.
 
-Cloudscale doesn't have a DNS service.
+cloudscale.ch doesn't have a DNS service.
 Use the VSHN DNS server instead.
 ====
 

--- a/docs/modules/ROOT/pages/references/cloudscale/config.adoc
+++ b/docs/modules/ROOT/pages/references/cloudscale/config.adoc
@@ -2,7 +2,7 @@
 
 [abstract]
 The OpenShift cluster setup can be customized by configuring `.parameters.openshift4_terraform.terraform_variables`.
-This page gives an overview of the configuration options, when setting up a cluster on Cloudscale.
+This page gives an overview of the configuration options, when setting up a cluster on cloudscale.ch.
 Further information on the Terraform module and its configuration can be found on https://github.com/appuio/terraform-openshift4-cloudscale[GitHub].
 
 

--- a/docs/modules/ROOT/partials/install/configure-installer.adoc
+++ b/docs/modules/ROOT/partials/install/configure-installer.adoc
@@ -1,8 +1,3 @@
-[TIP]
-====
-Starting with this section, we recommend that you change into a clean directory (for example a directory in your home).
-====
-
 . Generate SSH key
 +
 [NOTE]

--- a/docs/modules/ROOT/partials/install/prepare-commodore.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-commodore.adoc
@@ -1,6 +1,9 @@
 === Prepare Cluster Repository
 
-For the following steps, change into a clean directory (for example a directory in your home).
+[TIP]
+====
+Starting with this section, we recommend that you change into a clean directory (for example a directory in your home).
+====
 
 [NOTE]
 ====


### PR DESCRIPTION
* Ensure we always use "cloudscale.ch" spelling
* Add a call out to remind engineers to use the CCSP login and not their personal login during cluster setup
* Move tip regarding switching to a clean directory to the right position in the install instructions
* Fix formatting of bootstrap bucket cleanup step in cloudscale.ch install instructions