### PR TITLE
Add step to label nodes with their node-class on APPUiO Cloud

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/add_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/add_node.adoc
@@ -53,7 +53,7 @@ git push -u origin add-worker-node
 :kubectl_extra_args: --as=cluster-admin
 include::partial$install/approve-node-csrs.adoc[]
 
-== Label Node 
+== Label Node
 
 . Check for the node name
 +
@@ -67,4 +67,11 @@ kubectl get node
 [source,bash]
 ----
 kubectl --as=cluster-admin label node worker-XXXX node-role.kubernetes.io/app=""
+----
+
+. [APPUiO Cloud only] Add node-class label (flex or plus)
++
+[source,bash]
+----
+kubectl --as=cluster-admin label node worker-XXXX appuio.io/node-class=xxxx
 ----


### PR DESCRIPTION
When adding new nodes on APPUiO Cloud the node-class label needs to be set