### PR TITLE
Add step to enable AppCat during installation on Cloudscale

### DIFF
--- a/docs/modules/ROOT/partials/install/prepare-commodore.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-commodore.adoc
@@ -40,6 +40,24 @@ git push
 popd
 ----
 
+
+ifeval::["{provider}" == "cloudscale"]
+. Add AppCat to cluster configuration
++
+[source,bash]
+----
+pushd "inventory/classes/${TENANT_ID}/"
+
+yq eval -i '.classes += ["global.apps.appcat"]' ${CLUSTER_ID}.yml
+
+git commit -a -m "Add AppCat addon to ${CLUSTER_ID}"
+
+git push
+popd
+----
+endif::[]
+
+
 . Compile catalog
 +
 include::partial$install/commodore-dynfacts.adoc[]


### PR DESCRIPTION
AppCat should now be enabled by default on APPUiO Managed OpenShift on Cloudscale. This simply requires adding a single class and will reuse the Cloudscale token stored under `${cluster:tenant}/${cluster:name}/cloudscale/token` to provision buckets on cloudscale