### PR TITLE
Rename YAML key from `on` to `events`

### DIFF
--- a/docs/modules/ROOT/pages/references/architecture/upgrade_controller.adoc
+++ b/docs/modules/ROOT/pages/references/architecture/upgrade_controller.adoc
@@ -280,7 +280,7 @@ kind: UpgradeJobHook
 metadata:
   name: cluster-upgrade-notify-ext
 spec:
-  on: <1>
+  events: <1>
     - Create
     - Start
     - Finish


### PR DESCRIPTION
Fixes key getting parsed as boolean without quotes.