### PR TITLE
Make OCP 4.14 and k8s 1.27 the default

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -1,6 +1,6 @@
 = Install OpenShift 4 on cloudscale.ch
-:ocp-minor-version: 4.13
-:k8s-minor-version: 1.26
+:ocp-minor-version: 4.14
+:k8s-minor-version: 1.27
 :ocp-patch-version: {ocp-minor-version}.0
 :provider: cloudscale
 

--- a/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
@@ -1,6 +1,6 @@
 = Install OpenShift 4 on OpenStack
-:ocp-minor-version: 4.13
-:k8s-minor-version: 1.26
+:ocp-minor-version: 4.14
+:k8s-minor-version: 1.27
 :ocp-patch-version: {ocp-minor-version}.0
 :provider: openstack
 

--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -1,6 +1,6 @@
 = Install OpenShift 4 on vSphere
-:ocp-minor-version: 4.13
-:k8s-minor-version: 1.26
+:ocp-minor-version: 4.14
+:k8s-minor-version: 1.27
 :ocp-patch-version: {ocp-minor-version}.0
 :provider: vsphere
 


### PR DESCRIPTION
exoscale already covered in #320