### PR TITLE
Remove step to copy the cert-manager acme-dns secret

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -206,10 +206,6 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/global-backup \
 # Generate a password for the cluster object backups
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
   password=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
-
-# Copy the VSHN acme-dns registration password
-vault kv get -format=json "clusters/kv/template/cert-manager" | jq '.data.data' \
-  | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cert-manager" -
 ----
 
 include::partial$get-hieradata-token-from-vault.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -186,10 +186,6 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/global-backup \
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
   password=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
 
-# Copy the VSHN acme-dns registration password
-vault kv get -format=json "clusters/kv/template/cert-manager" | jq '.data.data' \
-  | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cert-manager" -
-
 # Set the AppCat Provider Exoscale Credentials
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/appcat/provider-exoscale \
   access-key=${APPCAT_ACCESSKEY} \

--- a/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
@@ -140,11 +140,6 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/global-backup \
 # Generate a password for the cluster object backups
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
   password=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
-
-# Copy the VSHN acme-dns registration password
-vault kv get -format=json "clusters/kv/template/cert-manager" | jq '.data.data' \
-  | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cert-manager" -
-
 ----
 
 === Setup floating IPs and DNS records for the API and ingress

--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -104,11 +104,6 @@ vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/global-backup \
 # Generate a password for the cluster object backups
 vault kv put clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cluster-backup \
   password=$(LC_ALL=C tr -cd "A-Za-z0-9" </dev/urandom | head -c 32)
-
-# Copy the VSHN acme-dns registration password
-vault kv get -format=json "clusters/kv/template/cert-manager" | jq '.data.data' \
-  | vault kv put -cas=0 "clusters/kv/${TENANT_ID}/${CLUSTER_ID}/cert-manager" -
-
 ----
 
 include::partial$install/prepare-commodore.adoc[]


### PR DESCRIPTION
We now reference the shared secret in the VSHN global defaults, so this step isn't necessary anymore.\

See also [the global-defaults change (internal)](https://git.vshn.net/syn/commodore-defaults/-/merge_requests/1724).