### PR TITLE
Use amtool in the alertmanager pod instead of silencing job

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/network/migrate-to-cilium.adoc
+++ b/docs/modules/ROOT/pages/how-tos/network/migrate-to-cilium.adoc
@@ -12,17 +12,10 @@
 
 IMPORTANT: Make sure that your `$KUBECONFIG` points to the cluster you want to migrate before starting.
 
-. Silence all Project Syn alerts
-+
-[source,bash]
-----
-silence_id=$(
-    kubectl --as=cluster-admin -n openshift-monitoring exec \
-    sts/alertmanager-main -- amtool --alertmanager.url=http://localhost:9093 \
-    silence add alertname!=Watchdog --duration="3h" -c "cilium migration"
-)
-echo $silence_id
-----
+:alert_statement: alertname!=Watchdog
+:duration: 3h
+:comment: cilium migration
+include::partial$create-amtool-silence.adoc[]
 
 . Select cluster
 +
@@ -277,10 +270,4 @@ include::partial$enable-argocd-autosync.adoc[]
 
 == Cleanup alert silence
 
-. Expire the silence
-+
-[source,bash]
-----
-kubectl --as=cluster-admin -n openshift-monitoring exec sts/alertmanager-main --\
-    amtool --alertmanager.url=http://localhost:9093 silence expire $silence_id
-----
+include::partial$expire-amtool-silence.adoc[]

--- a/docs/modules/ROOT/pages/how-tos/network/migrate-to-cilium.adoc
+++ b/docs/modules/ROOT/pages/how-tos/network/migrate-to-cilium.adoc
@@ -12,8 +12,17 @@
 
 IMPORTANT: Make sure that your `$KUBECONFIG` points to the cluster you want to migrate before starting.
 
-:duration: +120 minutes
-include::partial$create-alertmanager-silence-all-projectsyn.adoc[]
+. Silence all Project Syn alerts
++
+[source,bash]
+----
+silence_id=$(
+    kubectl --as=cluster-admin -n openshift-monitoring exec \
+    sts/alertmanager-main -- amtool --alertmanager.url=http://localhost:9093 \
+    silence add alertname!=Watchdog --duration="3h" -c "cilium migration"
+)
+echo $silence_id
+----
 
 . Select cluster
 +
@@ -268,4 +277,10 @@ include::partial$enable-argocd-autosync.adoc[]
 
 == Cleanup alert silence
 
-include::partial$remove-alertmanager-silence-all-projectsyn.adoc[]
+. Expire the silence
++
+[source,bash]
+----
+kubectl --as=cluster-admin -n openshift-monitoring exec sts/alertmanager-main --\
+    amtool --alertmanager.url=http://localhost:9093 silence expire $silence_id
+----

--- a/docs/modules/ROOT/partials/create-amtool-silence.adoc
+++ b/docs/modules/ROOT/partials/create-amtool-silence.adoc
@@ -1,0 +1,12 @@
+// see https://manpages.debian.org/unstable/prometheus-alertmanager/amtool.1.en.html#silence_add_%5B%3Cflags%3E%5D_%5B%3Cmatcher-groups%3E...%5D
+. Create alertmanager silence
++
+[source,bash,subs="attributes+"]
+----
+silence_id=$(
+    kubectl --as=cluster-admin -n openshift-monitoring exec \
+    sts/alertmanager-main -- amtool --alertmanager.url=http://localhost:9093 \
+    silence add {alert_statement} --duration="{duration}" -c "{comment}"
+)
+echo $silence_id
+----

--- a/docs/modules/ROOT/partials/expire-amtool-silence.adoc
+++ b/docs/modules/ROOT/partials/expire-amtool-silence.adoc
@@ -1,0 +1,8 @@
+// see https://manpages.debian.org/unstable/prometheus-alertmanager/amtool.1.en.html#silence_expire_%5B%3Csilence-ids%3E...%5D
+. Expire alertmanager silence
++
+[source,bash]
+----
+kubectl --as=cluster-admin -n openshift-monitoring exec sts/alertmanager-main --\
+    amtool --alertmanager.url=http://localhost:9093 silence expire $silence_id
+----


### PR DESCRIPTION
Reduces the number of manual steps needed (no cleanup of jobs etc.) and reduces the wall of code in the how-to