### PR TITLE
Add pausing ArgoCD to replace storage node documentation

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/replace-storage-node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/replace-storage-node.adoc
@@ -41,10 +41,15 @@ include::partial$cloudscale/configure-terraform-secrets.adoc[]
 
 include::partial$setup_terraform.adoc[]
 
-== Set alert silence
+== Set alert silence and pause ArgoCD
 
 :duration: +60 minutes
 include::partial$create-alertmanager-silence.adoc[]
+
+. Disable auto sync for component `rook-ceph`.
+This allows us to temporarily make manual changes to the Rook Ceph cluster.
++
+include::partial$disable-argocd-autosync.adoc[]
 
 == Replace node
 
@@ -70,6 +75,8 @@ include::partial$delete-node.adoc[]
 == Finish up
 
 include::partial$remove-alertmanager-silence.adoc[]
+
+include::partial$enable-argocd-autosync.adoc[]
 
 == Upstream documentation
 

--- a/docs/modules/ROOT/pages/how-tos/exoscale/replace_storage_node.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/replace_storage_node.adoc
@@ -41,10 +41,15 @@ include::partial$exoscale/configure-terraform-secrets.adoc[]
 
 include::partial$setup_terraform.adoc[]
 
-== Set alert silence
+== Set alert silence and pause ArgoCD
 
 :duration: +60 minutes
 include::partial$create-alertmanager-silence.adoc[]
+
+. Disable auto sync for component `rook-ceph`.
+This allows us to temporarily make manual changes to the Rook Ceph cluster.
++
+include::partial$disable-argocd-autosync.adoc[]
 
 == Replace node
 

--- a/docs/modules/ROOT/partials/storage-ceph-remove-mon.adoc
+++ b/docs/modules/ROOT/partials/storage-ceph-remove-mon.adoc
@@ -84,18 +84,6 @@ kubectl --as=cluster-admin -n syn-rook-ceph-cluster exec -it deploy/rook-ceph-to
 kubectl --as=cluster-admin -n syn-rook-ceph-cluster get deploy -l app=rook-ceph-mon
 ----
 
-. Reset the MON failover timeout
-+
-[source,bash]
-----
-kubectl --as=cluster-admin -n syn-rook-ceph-cluster patch cephcluster cluster --type=json \
-  -p '[{
-    "op": "replace",
-    "path": "/spec/healthCheck/daemonHealth/mon",
-    "value": {}
-  }]'
-----
-
 ifeval::["{mon-argocd-autosync-already-disabled}" != "yes"]
 include::partial$enable-argocd-autosync.adoc[]
 endif::[]


### PR DESCRIPTION
Due to added defaults in component-rook-ceph, update node replacement documentation.
https://github.com/projectsyn/component-rook-ceph/pull/156