### PR TITLE
Update install instructions for OpenShift 4.15 and Cilium kube-proxy-free mode

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
@@ -54,7 +54,7 @@ done
 +
 [source,console]
 ----
-terraform state rm module.cluster.module.lb.module.hiera.gitfile_checkout.appuio_hieradata
+terraform state rm module.cluster.module.lb.module.hiera[0].gitfile_checkout.appuio_hieradata
 ----
 +
 NOTE: This step is necessary to ensure the subsequent `terraform destroy` completes without errors.

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -1,6 +1,6 @@
 = Install OpenShift 4 on cloudscale.ch
-:ocp-minor-version: 4.14
-:k8s-minor-version: 1.27
+:ocp-minor-version: 4.15
+:k8s-minor-version: 1.28
 :ocp-patch-version: {ocp-minor-version}.0
 :provider: cloudscale
 

--- a/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/install.adoc
@@ -1,7 +1,7 @@
 = Install OpenShift 4 on cloudscale.ch
 :ocp-minor-version: 4.15
 :k8s-minor-version: 1.28
-:ocp-patch-version: {ocp-minor-version}.0
+:ocp-patch-version: {ocp-minor-version}.23
 :provider: cloudscale
 
 [abstract]

--- a/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/exoscale/install.adoc
@@ -1,7 +1,7 @@
 = Installation on Exoscale
 :ocp-minor-version: 4.15
 :k8s-minor-version: 1.28
-:ocp-patch-version: {ocp-minor-version}.0
+:ocp-patch-version: {ocp-minor-version}.23
 :provider: exoscale
 :kubectl_extra_args:
 

--- a/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
@@ -1,6 +1,6 @@
 = Install OpenShift 4 on OpenStack
-:ocp-minor-version: 4.14
-:k8s-minor-version: 1.27
+:ocp-minor-version: 4.15
+:k8s-minor-version: 1.28
 :ocp-patch-version: {ocp-minor-version}.0
 :provider: openstack
 

--- a/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/openstack/install.adoc
@@ -1,7 +1,7 @@
 = Install OpenShift 4 on OpenStack
 :ocp-minor-version: 4.15
 :k8s-minor-version: 1.28
-:ocp-patch-version: {ocp-minor-version}.0
+:ocp-patch-version: {ocp-minor-version}.23
 :provider: openstack
 
 [abstract]

--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -1,6 +1,6 @@
 = Install OpenShift 4 on vSphere
-:ocp-minor-version: 4.14
-:k8s-minor-version: 1.27
+:ocp-minor-version: 4.15
+:k8s-minor-version: 1.28
 :ocp-patch-version: {ocp-minor-version}.0
 :provider: vsphere
 

--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -1,7 +1,7 @@
 = Install OpenShift 4 on vSphere
 :ocp-minor-version: 4.15
 :k8s-minor-version: 1.28
-:ocp-patch-version: {ocp-minor-version}.0
+:ocp-patch-version: {ocp-minor-version}.23
 :provider: vsphere
 
 [abstract]

--- a/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
+++ b/docs/modules/ROOT/partials/install/bootstrap-nodes.adoc
@@ -38,6 +38,46 @@ while ! curl --connect-timeout 1 "${API_URL}/healthz" -k &>/dev/null; do
 done && echo -e "\nAPI is up"
 ----
 
+. Patch Cilium config to allow control plane bootstrap to succeed
++
+[NOTE]
+====
+We need to temporarily adjust the Cilium config to not use full kube-proxy replacement, since we currently don't have a way to disable the initial OpenShift-managed kube-proxy deployment.
+Additionally, Because the cloudscale Cloud Controller Manager accesses the K8s API via service IP, we need to configure Cilium to provide partial kube-proxy replacement so that the CCM can start and untaint the control plane nodes so that other pods can be scheduled.
+====
++
+[source,bash]
+----
+export KUBECONFIG="${INSTALLER_DIR}/auth/kubeconfig"
+
+while ! kubectl get ciliumconfig -A &>/dev/null; do
+  echo -n "."
+  sleep 2
+done && echo -e "\nCiliumConfig CR is present"
+
+kubectl patch -n cilium ciliumconfig cilium-enterprise --type=merge \
+ -p '{
+  "spec": {
+    "cilium": {
+      "kubeProxyReplacement": "false",
+      "nodePort": {
+        "enabled": true
+      },
+      "socketLB": {
+        "enabled": true
+      },
+      "sessionAffinity": true,
+      "externalIPs": {
+        "enabled": true
+      },
+      "hostPort": {
+        "enabled": true
+      }
+    }
+  }
+ }'
+----
+
 . Deploy control plane nodes
 +
 [source,bash,subs="attributes+"]
@@ -92,6 +132,20 @@ terraform apply
 popd
 ----
 
+. Disable OpenShift kube-proxy deployment and revert Cilium patch
++
+[source,bash]
+----
+kubectl patch network.operator cluster --type=merge \
+  -p '{"spec":{"deployKubeProxy":false}}'
+kubectl -n cilium replace -f catalog/manifests/cilium/olm/cluster-network-07-cilium-ciliumconfig.yaml
+while ! kubectl -n cilium get cm cilium-config -oyaml | grep 'kube-proxy-replacement: "true"' &>/dev/null; do
+  echo -n "."
+  sleep 2
+done && echo -e "\nCilium config updated"
+kubectl -n cilium rollout restart ds/cilium
+----
+
 . Review and merge the LB hieradata MR (listed in Terraform output `hieradata_mr`) and run Puppet on the LBs after the deploy job has completed
 +
 [source,bash]
@@ -102,11 +156,6 @@ done
 ----
 
 . Approve node certs
-+
-[source,bash]
-----
-export KUBECONFIG="${INSTALLER_DIR}/auth/kubeconfig"
-----
 +
 include::partial$install/approve-node-csrs.adoc[]
 


### PR DESCRIPTION
* Bump OpenShift and K8s versions in cloudscale, OpenStack and vSphere instructions
* Add steps to allow control plane bootstrap to complete with Cilium in kube-proxy-free mode