### PR TITLE
Folder with infraID is created automatically by the installer

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -64,7 +64,6 @@ export VSPHERE_CLUSTER=<cluster name>
 export VSPHERE_DATACENTER=<datacenter name>
 export VSPHERE_DATASTORE=<datastore name>
 export VSPHERE_NETWORK=<network name>
-export VSPHERE_FOLDER=<folder name>
 ----
 
 .Cluster machine network

--- a/docs/modules/ROOT/partials/install/install-config-vsphere.adoc
+++ b/docs/modules/ROOT/partials/install/install-config-vsphere.adoc
@@ -52,6 +52,7 @@ platform:
           networks:
             - ${VSPHERE_NETWORK}
           resourcePool: "/${VSPHERE_DATACENTER}/host/${VSPHERE_CLUSTER}//Resources"
+          folder: "" <3>
     ingressVIPs:
       - ${INGRESS_VIP}
     vcenters:
@@ -74,3 +75,4 @@ EOF
 Otherwise, the installation will most likely fail.
 <2> We only provision a single compute machine set.
 The final machine sets will be configured through Project Syn.
+<3> The installer will by default create a top-level folder with the vsphere infraID, but you can optionally choose an existing folder (https://docs.openshift.com/container-platform/4.15/installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere[docs]).

--- a/docs/modules/ROOT/partials/install/install-config-vsphere.adoc
+++ b/docs/modules/ROOT/partials/install/install-config-vsphere.adoc
@@ -52,7 +52,6 @@ platform:
           networks:
             - ${VSPHERE_NETWORK}
           resourcePool: "/${VSPHERE_DATACENTER}/host/${VSPHERE_CLUSTER}//Resources"
-          folder: "/${VSPHERE_DATACENTER}/vm/${VSPHERE_FOLDER}"
     ingressVIPs:
       - ${INGRESS_VIP}
     vcenters:

--- a/docs/modules/ROOT/partials/install/prepare-syn-config-vsphere.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-syn-config-vsphere.adoc
@@ -14,6 +14,6 @@ yq eval -i ".parameters.openshift.vsphere.datastore = \"${VSPHERE_DATASTORE}\"" 
 yq eval -i ".parameters.openshift.vsphere.server = \"${VCENTER_HOSTNAME}\"" \
   ${CLUSTER_ID}.yml
 
-yq eval -i ".parameters.openshift.vsphere.folder = \"${VSPHERE_FOLDER}\"" \
+yq eval -i ".parameters.openshift.vsphere.folder = .parameters.openshift.infraID" \
   ${CLUSTER_ID}.yml
 ----


### PR DESCRIPTION
https://docs.openshift.com/container-platform/4.15/installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-config-parameters-vsphere

From the docs:
 > Optional: The absolute path of an existing folder where the user creates the virtual machines, for example, /<datacenter_name>/vm/<folder_name>/<subfolder_name>. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID.