### PR TITLE
Update Cilium migration how-to to always use `api-int`

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/network/migrate-to-cilium.adoc
+++ b/docs/modules/ROOT/pages/how-tos/network/migrate-to-cilium.adoc
@@ -148,18 +148,15 @@ yq eval -i '.parameters.networkpolicy.ignoredNamespaces = ["openshift-oauth-apis
 [source,bash]
 ----
 export CLUSTER_DOMAIN=$(kubectl get dns cluster -ojsonpath='{.spec.baseDomain}')
-kubectl --as=cluster-admin -n openshift-dns exec ds/node-resolver -- nslookup api-int.${CLUSTER_DOMAIN}
+kubectl --as=cluster-admin -n openshift-dns exec ds/node-resolver -- dig +short api-int.${CLUSTER_DOMAIN}
 ----
 +
-[TIP]
+[NOTE]
 ====
-If the command doesn't return a valid record for `api-int`, the Cilium config needs to be adjusted to use the `api` record to ensure that the Kubernetes API can be accessed.
+The command should always return a valid record for `api-int`.
 
-[source,bash]
-----
-yq -i '.parameters.cilium.cilium_helm_values.k8sServiceHost="api.${openshift:baseDomain}"' \
-  "${CLUSTER_ID}.yml"
-----
+If it doesn't, please check that the OpenShift DNS cluster operator is healthy and double-check that the record is being resolved on the internal DNS for clusters on vSphere.
+You can see more details about the lookup by omitting the `+short` flag for the `dig` command.
 ====
 
 . Configure component `cilium`.


### PR DESCRIPTION
We can't use the public `api` record since Cilium simply patches the clientset generated by [`InClusterConfig()`](https://pkg.go.dev/k8s.io/client-go/rest#InClusterConfig) with the provided API host name, cf. https://github.com/cilium/cilium/blob/bb81b095cb64053887e3cb087b53518c162beec6/pkg/k8s/client/cell.go#L348-L352. Notably, the clientset still uses the K8s-managed in-cluster CA bundle which isn't suitable for validating public certificates.

If we actually want to use `api` record, we'd have to somehow configure Cilium to use a custom kubeconfig (which I'm not sure is possible when running Cilium in a cluster).