### PR TITLE
Update decommissioning instructions for cloudscale

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
+++ b/docs/modules/ROOT/pages/how-tos/cloudscale/decommission.adoc
@@ -21,7 +21,6 @@ include::partial$cloudscale/prerequisites.adoc[]
 +
 [source,bash]
 ----
-export CLUSTER_ID=<lieutenant-cluster-id>
 export GITLAB_TOKEN=<gitlab-api-token> # From https://git.vshn.net/-/user_settings/personal_access_tokens
 export GITLAB_USER=<gitlab-user-name>
 ----
@@ -30,22 +29,15 @@ export GITLAB_USER=<gitlab-user-name>
 +
 include::partial$connect-to-vault.adoc[]
 +
+include::partial$commodore-init.adoc[]
++
 [source,bash]
 ----
-export TENANT_ID=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .tenant)
 export CLOUDSCALE_API_TOKEN=$(vault kv get -format=json clusters/kv/$TENANT_ID/$CLUSTER_ID/cloudscale | jq -r .data.data.token)
 export REGION=$(curl -sH "Authorization: Bearer $(commodore fetch-token)" ${COMMODORE_API_URL}/clusters/${CLUSTER_ID} | jq -r .facts.region)
 export BACKUP_REGION=$(curl -H "Authorization: Bearer ${CLOUDSCALE_API_TOKEN}" https://api.cloudscale.ch/v1/regions | jq -r '.[].slug' | grep -v $REGION)
 export HIERADATA_REPO_SECRET=$(vault kv get \
   -format=json "clusters/kv/lbaas/hieradata_repo_token" | jq -r '.data.data.token')
-----
-
-. Compile the catalog for the cluster.
-Having the catalog available locally enables us to run Terraform for the cluster to make any required changes.
-+
-[source,bash]
-----
-commodore catalog compile "${CLUSTER_ID}"
 ----
 
 . Configure Terraform secrets
@@ -69,7 +61,7 @@ for id in 1 2; do
   LB_FQDNS[$id]=$(terraform state show "module.cluster.module.lb.cloudscale_server.lb[$(expr $id - 1)]" | grep fqdn | awk '{print $2}' | tr -d ' "\r\n')
 done
 for lb in ${LB_FQDNS[*]}; do
-  ssh "${lb}" "sudo grep 'server =' /etc/burp/burp.conf && sudo grep 'ParentZone' /etc/icinga2/constants.conf"
+  ssh "${lb}" "sudo grep 'server =' /etc/burp/burp.conf && sudo grep 'ParentZone' /etc/icinga2/constants.conf" | tee "../../../$lb.info"
 done
 ----
 
@@ -159,6 +151,21 @@ done
 
 . Decommission Puppet-managed LBs according to the https://wiki.vshn.net/display/VT/How+To%3A+Decommission+a+VM[VSHN documentation] (Internal link).
 +
+[NOTE]
+--
+The documentation linked above requires some information to be retrieved from the already-deleted load balancers.
+
+If you've been following these instructions, you stored this information into a file earlier:
+
+[source,bash]
+----
+for lb in ${LB_FQDNS[*]}; do
+  echo "$lb"
+  cat "$lb.info"
+done
+----
+--
++
 NOTE: Don't forget to remove the LB configuration in the https://git.vshn.net/appuio/appuio_hieradata/-/tree/master/lbaas[APPUiO hieradata] and the https://git.vshn.net/vshn-puppet/nodes_hieradata[nodes hieradata].
 
 . Delete cluster from Lieutenant API (via portal)
@@ -174,16 +181,6 @@ Go to https://control.vshn.net/syn/lieutenantclusters
 . Delete all remaining volumes which were associated with the cluster in the cloudscale.ch project.
 +
 TIP: This step is required because the csi-cloudscale driver doesn't have time to properly cleanup PVs when the cluster is decommissioned with `terraform destroy`.
-
-. Delete the cluster-backup bucket in the cloudscale.ch project
-+
-[NOTE]
-====
-Verify that the cluster backups aren't needed anymore before cleaning up the backup bucket.
-Consider extracting the most recent cluster objects and etcd backups before deleting the bucket.
-See the xref:how-tos/recover-from-backup.adoc[Recover objects from backup] how-to for instructions.
-At this point in the decommissioning process, you'll have to extract the Restic configuration from Vault instead of the cluster itself.
-====
 
 . Delete the cluster's API tokens in the cloudscale UI
 


### PR DESCRIPTION
- The Commodore setup instructions were incomplete. I decided to move to the partial. As a result, some Commodore related steps are no longer explicitly listed.
- The removal of the backup bucket was duplicated (once with minio, once via cloudscale console). I removed the instruction to remove the bucket in the console.
- I added a command to store the load balancer puppet metadata in a file, and a note at the appropriate point on how to retrieve it.