### PR TITLE
Update vSphere install instructions for OpenShift 4.16

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -11,12 +11,6 @@ Steps to install an OpenShift 4 cluster on VMWare vSphere.
 These steps follow the https://docs.openshift.com/container-platform/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html[Installing a cluster on vSphere] docs to set up an installer provisioned installation (IPI).
 --
 
-[IMPORTANT]
---
-This how-to guide is an early draft.
-So far, we've setup only one cluster using the instructions in this guide.
---
-
 [NOTE]
 --
 The certificates created during bootstrap are only valid for 24h.

--- a/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
+++ b/docs/modules/ROOT/pages/how-tos/vsphere/install.adoc
@@ -103,16 +103,7 @@ include::partial$install/prepare-commodore.adoc[]
 
 include::partial$install/configure-installer.adoc[]
 
-[#_prepare_installer]
-=== Prepare the OpenShift Installer
-
-include::partial$install/run-installer.adoc[]
-
-=== Update Project Syn cluster config
-
-include::partial$install/prepare-syn-config.adoc[]
-
-=== Provision the cluster
+=== Establish connection to vSphere
 
 include::partial$install/socks5-proxy.adoc[]
 
@@ -128,6 +119,52 @@ rm vsphere-ca.zip
 sudo update-ca-certificates
 ----
 
+. Check if the vCenter hostname resolves on the host where you plan to execute `openshift-install`
++
+[source,bash]
+----
+vcenter_ip=$(dig +short ${VCENTER_HOSTNAME})
+if [ -z "${vcenter_ip}" ]; then
+  echo -e "\033[0;31m${VCENTER_HOSTNAME} doesn't resolve on your host.\033[0;0m"
+else
+  echo -e "\033[0;32m${VCENTER_HOSTNAME} resolves to ${vcenter_ip}.\033[0;0m"
+fi
+----
+
+. If the previous step printed a red message, setup a temporary entry in `/etc/hosts` for the vCenter hostname
++
+NOTE: This step assumes that you access vCenter via a management jumphost and have set `$JUMPHOST_FQDN` as shown in the info box above.
++
+.Set IP for vCenter hostname in your `/etc/hosts`
+[source,bash]
+----
+vcenter_ip=$(ssh $JUMPHOST_FQDN dig +short "$VCENTER_HOSTNAME")
+sudo sh -c "echo \"\n$vcenter_ip $VCENTER_HOSTNAME\" >> /etc/hosts"
+----
++
+.Recheck local resolution
+[source,bash]
+----
+vcenter_ip=$(dig +short ${VCENTER_HOSTNAME})
+if [ -z "${vcenter_ip}" ]; then
+  echo -e "\033[0;31m${VCENTER_HOSTNAME} doesn't resolve on your host.\033[0;0m"
+else
+  echo -e "\033[0;32m${VCENTER_HOSTNAME} resolves to ${vcenter_ip}.\033[0;0m"
+fi
+----
+
+
+[#_prepare_installer]
+=== Prepare the OpenShift Installer
+
+include::partial$install/run-installer.adoc[]
+
+=== Update Project Syn cluster config
+
+include::partial$install/prepare-syn-config.adoc[]
+
+=== Provision the cluster
+
 . Run the OpenShift installer
 +
 [source,bash]
@@ -135,6 +172,20 @@ sudo update-ca-certificates
 openshift-install --dir "${INSTALLER_DIR}" \
   create cluster --log-level=debug
 ----
++
+[TIP]
+====
+For OpenShift 4.16 and newer, `openshift-install` spins up a local Cluster-API environment using `envtest`.
+
+If provisioning the bootstrap and control-plane nodes isn't successful, you can access the `envtest` Kubernetes API as follows:
+
+[source,bash]
+----
+export KUBECONFIG="${INSTALLER_DIR}/.clusterapi_output/envtest.kubeconfig"
+kubectl get cluster -A <1>
+----
+<1> Should show one resource in namespace `openshift-cluster-api-guests`
+====
 
 === Access cluster API
 

--- a/docs/modules/ROOT/partials/install/prepare-syn-config.adoc
+++ b/docs/modules/ROOT/partials/install/prepare-syn-config.adoc
@@ -85,6 +85,13 @@ endif::[]
 [#_compile_catalog]
 === Commit changes and compile cluster catalog
 
+ifeval::["{provider}" == "vsphere"]
+:manage-https-proxy: yes
+endif::[]
+ifeval::["{provider}" == "openstack"]
+:manage-https-proxy: yes
+endif::[]
+
 . Review changes.
 Have a look at the file `${CLUSTER_ID}.yml`.
 Override default parameters or add more component configurations as required for your cluster.
@@ -107,6 +114,27 @@ git push
 popd
 ----
 
+ifeval::["{manage-https-proxy}" == "yes"]
+. Temporarily unset `https_proxy` since Commodore currently doesn't support `https_proxy`
++
+[source,bash]
+----
+https_proxy_bak=$https_proxy
+unset https_proxy
+----
++
+TIP: You can skip this step and "Restore https_proxy" if you're not using a HTTPS proxy for the installation.
+endif::[]
+
 . Compile and push cluster catalog
 +
 include::partial$install/commodore-dynfacts.adoc[]
+
+ifeval::["{manage-https-proxy}" == "yes"]
+. Restore `https_proxy`
++
+[source,bash]
+----
+export https_proxy=$https_proxy_bak
+----
+endif::[]

--- a/docs/modules/ROOT/partials/install/run-installer.adoc
+++ b/docs/modules/ROOT/partials/install/run-installer.adoc
@@ -9,6 +9,15 @@ If you have to recreate the install config or any of the generated manifests you
 openshift-install --dir "${INSTALLER_DIR}" \
   create manifests
 ----
+ifeval::["{provider}" == "vsphere"]
++
+[IMPORTANT]
+====
+If this step prints `WARNING unable to resolve vSphere server <vcenter hostname>`, please make sure that `dig +short ${VCENTER_HOSTNAME}` returns an IP on the host where you're running `openshift-install`.
+
+If you ignore this warning, `openshift-install create cluster` will not create the bootstrap and control-plane nodes.
+====
+endif::[]
 
 .. If you want to change the default "apps" domain for the cluster:
 +

--- a/docs/modules/ROOT/partials/install/socks5-proxy.adoc
+++ b/docs/modules/ROOT/partials/install/socks5-proxy.adoc
@@ -8,7 +8,7 @@ endif::[]
 
 [NOTE]
 ====
-The steps in this section must be run on a host which can reach the {provider-display} API.
+The steps related to `openshift-install` must be run on a host which can reach the {provider-display} API.
 If you can't reach the {provider-display} API directly, but a SSH jumphost is available, you can setup a SOCKS5 proxy with the following commands:
 
 [source,bash]


### PR DESCRIPTION
Reorder steps to ensure that we setup connectivity to vCenter early enough (before `openshift-install create manifests` for 4.16) and unset `https_proxy` when running Commodore.

Also remove the "early draft" note in the vSphere install instructions, since they're fairly battle-tested now.